### PR TITLE
feat: add multi-language support with locale-based routing

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -9,7 +9,8 @@
       "Bash(npx tsc:*)",
       "Bash(npm run build:*)",
       "Bash(gh issue list:*)",
-      "Bash(gh issue view:*)"
+      "Bash(gh issue view:*)",
+      "Bash(git stash:*)"
     ]
   }
 }

--- a/app/[locale]/blog/page.tsx
+++ b/app/[locale]/blog/page.tsx
@@ -1,15 +1,31 @@
 import { Metadata } from 'next';
+import { getTranslations, setRequestLocale } from 'next-intl/server';
 import { getAllPosts } from '@/lib/posts';
 import { ArticleCard } from '@/components/blog/article-card';
+import { Locale } from '@/lib/i18n';
 import { FileText } from 'lucide-react';
 
-export const metadata: Metadata = {
-  title: 'Blog',
-  description: 'Read articles about web development, programming, and technology.',
-};
+interface BlogPageProps {
+  params: Promise<{ locale: string }>;
+}
 
-export default function BlogPage() {
-  const posts = getAllPosts();
+export async function generateMetadata({ params }: BlogPageProps): Promise<Metadata> {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: 'blog' });
+
+  return {
+    title: t('title'),
+    description: t('description'),
+  };
+}
+
+export default async function BlogPage({ params }: BlogPageProps) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+
+  const t = await getTranslations('blog');
+  const typedLocale = locale as Locale;
+  const posts = getAllPosts(typedLocale);
 
   return (
     <div className="min-h-screen bg-background">
@@ -17,13 +33,13 @@ export default function BlogPage() {
         {/* Header */}
         <div className="mb-12">
           <h1 className="text-4xl font-bold text-foreground sm:text-5xl">
-            Blog
+            {t('title')}
           </h1>
           <p className="mt-4 text-lg text-muted-foreground">
-            Articles about web development, programming, and technology.
+            {t('description')}
           </p>
           <p className="mt-2 text-sm text-muted-foreground">
-            {posts.length} {posts.length === 1 ? 'article' : 'articles'} published
+            {t('articlesCount', { count: posts.length })}
           </p>
         </div>
 
@@ -40,6 +56,8 @@ export default function BlogPage() {
                 readingTime={post.readingTime}
                 tags={post.frontmatter.tags}
                 image={post.frontmatter.coverImage}
+                availableLocales={post.availableLocales}
+                isFallback={post.isFallback}
               />
             ))}
           </div>
@@ -47,10 +65,10 @@ export default function BlogPage() {
           <div className="flex flex-col items-center justify-center py-24 text-center">
             <FileText className="h-16 w-16 text-muted-foreground mb-4" />
             <h2 className="text-2xl font-semibold text-foreground mb-2">
-              No posts yet
+              {t('noPostsYet')}
             </h2>
             <p className="text-muted-foreground">
-              Check back soon for new content!
+              {t('checkBackSoon')}
             </p>
           </div>
         )}

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -1,0 +1,126 @@
+import type { Metadata } from "next"
+import { Lexend_Deca, Geist_Mono } from "next/font/google"
+import { Analytics } from "@vercel/analytics/react"
+import { NextIntlClientProvider } from 'next-intl'
+import { getMessages, setRequestLocale } from 'next-intl/server'
+import { notFound } from 'next/navigation'
+import { ThemeProvider } from "@/components/layout/theme-provider"
+import { Header } from "@/components/layout/header"
+import { Footer } from "@/components/layout/footer"
+import { Search } from "@/components/search/search"
+import { siteConfig } from "@/lib/config"
+import { locales, Locale, getLocalizedPath } from "@/lib/i18n"
+import "../globals.css"
+
+const lexend = Lexend_Deca({
+  variable: "--font-lexend",
+  subsets: ["latin"],
+  weight: ["300", "400", "600", "700"],
+})
+
+const geistMono = Geist_Mono({
+  variable: "--font-geist-mono",
+  subsets: ["latin"],
+})
+
+export function generateStaticParams() {
+  return locales.map((locale) => ({ locale }))
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>
+}): Promise<Metadata> {
+  const { locale } = await params
+
+  return {
+    title: {
+      default: siteConfig.name,
+      template: `%s | ${siteConfig.name}`,
+    },
+    description: siteConfig.description,
+    authors: [{ name: siteConfig.author.name }],
+    creator: siteConfig.author.name,
+    metadataBase: new URL(siteConfig.url),
+    openGraph: {
+      type: "website",
+      locale: locale === 'pt-BR' ? 'pt_BR' : 'en_US',
+      url: siteConfig.url,
+      title: siteConfig.name,
+      description: siteConfig.description,
+      siteName: siteConfig.name,
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: siteConfig.name,
+      description: siteConfig.description,
+      creator: siteConfig.author.twitter,
+    },
+    robots: {
+      index: true,
+      follow: true,
+      googleBot: {
+        index: true,
+        follow: true,
+        "max-video-preview": -1,
+        "max-image-preview": "large",
+        "max-snippet": -1,
+      },
+    },
+    alternates: {
+      canonical: locale === 'en' ? siteConfig.url : `${siteConfig.url}/pt-br`,
+      languages: {
+        'en': siteConfig.url,
+        'pt-BR': `${siteConfig.url}/pt-br`,
+        'x-default': siteConfig.url,
+      },
+    },
+  }
+}
+
+export default async function LocaleLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode
+  params: Promise<{ locale: string }>
+}) {
+  const { locale } = await params
+
+  // Validate locale
+  if (!locales.includes(locale as Locale)) {
+    notFound()
+  }
+
+  // Enable static rendering
+  setRequestLocale(locale)
+
+  const messages = await getMessages()
+
+  return (
+    <html lang={locale} suppressHydrationWarning>
+      <body
+        className={`${lexend.variable} ${geistMono.variable} font-sans antialiased`}
+      >
+        <NextIntlClientProvider messages={messages}>
+          <ThemeProvider
+            attribute="class"
+            defaultTheme="dark"
+            enableSystem
+            disableTransitionOnChange
+          >
+            <Search>
+              <div className="flex min-h-screen flex-col">
+                <Header />
+                <main className="flex-1">{children}</main>
+                <Footer />
+              </div>
+            </Search>
+          </ThemeProvider>
+        </NextIntlClientProvider>
+        <Analytics />
+      </body>
+    </html>
+  )
+}

--- a/app/[locale]/not-found.tsx
+++ b/app/[locale]/not-found.tsx
@@ -1,0 +1,26 @@
+import Link from 'next/link';
+import { useTranslations } from 'next-intl';
+import { Button } from '@/components/ui/button';
+import { Home } from 'lucide-react';
+
+export default function NotFound() {
+  const t = useTranslations('errors');
+
+  return (
+    <div className="flex min-h-[60vh] flex-col items-center justify-center px-4 text-center">
+      <h1 className="mb-4 text-6xl font-bold text-primary">404</h1>
+      <h2 className="mb-2 text-2xl font-semibold text-foreground">
+        {t('notFound')}
+      </h2>
+      <p className="mb-8 text-muted-foreground">
+        {t('notFoundDescription')}
+      </p>
+      <Button asChild>
+        <Link href="/">
+          <Home className="mr-2 h-4 w-4" />
+          {t('backHome')}
+        </Link>
+      </Button>
+    </div>
+  );
+}

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -1,14 +1,26 @@
 import Link from 'next/link';
+import { getLocale, getTranslations, setRequestLocale } from 'next-intl/server';
 import { Hero } from '@/components/home/hero';
 import { ArticleCard } from '@/components/blog/article-card';
 import { TagBadge } from '@/components/blog/tag-badge';
 import { getFeaturedPosts, getLatestPosts, getAllTags } from '@/lib/posts';
+import { getLocalizedPath, Locale } from '@/lib/i18n';
 import { ArrowRight } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 
-export default function HomePage() {
-  const featuredPosts = getFeaturedPosts();
-  const latestPosts = getLatestPosts(6);
+interface HomePageProps {
+  params: Promise<{ locale: string }>;
+}
+
+export default async function HomePage({ params }: HomePageProps) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+
+  const t = await getTranslations('sections');
+  const typedLocale = locale as Locale;
+
+  const featuredPosts = getFeaturedPosts(typedLocale);
+  const latestPosts = getLatestPosts(6, typedLocale);
   const tags = getAllTags();
 
   return (
@@ -21,10 +33,10 @@ export default function HomePage() {
           <div className="container mx-auto px-4">
             <div className="mb-12">
               <h2 className="text-3xl font-bold text-foreground sm:text-4xl">
-                Featured Articles
+                {t('featuredArticles')}
               </h2>
               <p className="mt-2 text-muted-foreground">
-                Handpicked posts you shouldn't miss
+                {t('featuredDescription')}
               </p>
             </div>
 
@@ -39,6 +51,8 @@ export default function HomePage() {
                   readingTime={post.readingTime}
                   tags={post.frontmatter.tags}
                   image={post.frontmatter.coverImage}
+                  availableLocales={post.availableLocales}
+                  isFallback={post.isFallback}
                 />
               ))}
             </div>
@@ -52,10 +66,10 @@ export default function HomePage() {
           <div className="mb-12 flex items-end justify-between">
             <div>
               <h2 className="text-3xl font-bold text-foreground sm:text-4xl">
-                Latest Articles
+                {t('latestArticles')}
               </h2>
               <p className="mt-2 text-muted-foreground">
-                Fresh insights and tutorials
+                {t('latestDescription')}
               </p>
             </div>
             <Button
@@ -63,8 +77,8 @@ export default function HomePage() {
               variant="ghost"
               className="hidden text-primary hover:text-primary/80 sm:flex"
             >
-              <Link href="/blog">
-                View all
+              <Link href={getLocalizedPath('/blog', typedLocale)}>
+                {t('viewAll')}
                 <ArrowRight className="ml-2 h-4 w-4" />
               </Link>
             </Button>
@@ -81,14 +95,16 @@ export default function HomePage() {
                 readingTime={post.readingTime}
                 tags={post.frontmatter.tags}
                 image={post.frontmatter.coverImage}
+                availableLocales={post.availableLocales}
+                isFallback={post.isFallback}
               />
             ))}
           </div>
 
           <div className="mt-12 text-center sm:hidden">
             <Button asChild variant="outline" className="w-full">
-              <Link href="/blog">
-                View all articles
+              <Link href={getLocalizedPath('/blog', typedLocale)}>
+                {t('viewAllArticles')}
                 <ArrowRight className="ml-2 h-4 w-4" />
               </Link>
             </Button>
@@ -102,10 +118,10 @@ export default function HomePage() {
           <div className="container mx-auto px-4">
             <div className="mb-12">
               <h2 className="text-3xl font-bold text-foreground sm:text-4xl">
-                Explore by Topic
+                {t('exploreByTopic')}
               </h2>
               <p className="mt-2 text-muted-foreground">
-                Browse articles by category
+                {t('browseByCategory')}
               </p>
             </div>
 
@@ -115,7 +131,7 @@ export default function HomePage() {
                   key={tag}
                   tag={tag}
                   count={count}
-                  href={`/tag/${encodeURIComponent(tag)}`}
+                  href={getLocalizedPath(`/tag/${encodeURIComponent(tag)}`, typedLocale)}
                 />
               ))}
             </div>

--- a/app/[locale]/tag/[tag]/page.tsx
+++ b/app/[locale]/tag/[tag]/page.tsx
@@ -1,24 +1,35 @@
 import { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
+import { getTranslations, setRequestLocale } from 'next-intl/server';
 import { getPostsByTag, getAllTags } from '@/lib/posts';
 import { ArticleCard } from '@/components/blog/article-card';
 import { Button } from '@/components/ui/button';
 import { ArrowLeft, Tag as TagIcon } from 'lucide-react';
+import { locales, Locale, getLocalizedPath } from '@/lib/i18n';
 
 interface TagPageProps {
-  params: Promise<{ tag: string }>;
+  params: Promise<{ locale: string; tag: string }>;
 }
 
 export async function generateStaticParams() {
   const tags = getAllTags();
-  return tags.map(({ tag }) => ({ tag: encodeURIComponent(tag) }));
+  const params: { locale: string; tag: string }[] = [];
+
+  for (const { tag } of tags) {
+    for (const locale of locales) {
+      params.push({ locale, tag: encodeURIComponent(tag) });
+    }
+  }
+
+  return params;
 }
 
 export async function generateMetadata({ params }: TagPageProps): Promise<Metadata> {
-  const { tag } = await params;
+  const { locale, tag } = await params;
   const decodedTag = decodeURIComponent(tag);
-  const posts = getPostsByTag(decodedTag);
+  const posts = getPostsByTag(decodedTag, locale as Locale);
+  const t = await getTranslations({ locale, namespace: 'tag' });
 
   if (posts.length === 0) {
     return {
@@ -27,15 +38,21 @@ export async function generateMetadata({ params }: TagPageProps): Promise<Metada
   }
 
   return {
-    title: `Posts tagged "${decodedTag}"`,
-    description: `Browse all articles tagged with ${decodedTag}. ${posts.length} ${posts.length === 1 ? 'article' : 'articles'} found.`,
+    title: t('title', { tag: decodedTag }),
+    description: `${t('articlesTagged', { count: posts.length })} ${decodedTag}.`,
   };
 }
 
 export default async function TagPage({ params }: TagPageProps) {
-  const { tag } = await params;
+  const { locale, tag } = await params;
+  setRequestLocale(locale);
+
+  const t = await getTranslations('tag');
+  const tArticle = await getTranslations('article');
+  const typedLocale = locale as Locale;
+
   const decodedTag = decodeURIComponent(tag);
-  const posts = getPostsByTag(decodedTag);
+  const posts = getPostsByTag(decodedTag, typedLocale);
 
   if (posts.length === 0) {
     notFound();
@@ -51,9 +68,9 @@ export default async function TagPage({ params }: TagPageProps) {
             variant="ghost"
             className="text-muted-foreground hover:text-primary"
           >
-            <Link href="/blog">
+            <Link href={getLocalizedPath('/blog', typedLocale)}>
               <ArrowLeft className="mr-2 h-4 w-4" />
-              Back to Blog
+              {tArticle('backToBlog')}
             </Link>
           </Button>
         </div>
@@ -62,7 +79,7 @@ export default async function TagPage({ params }: TagPageProps) {
         <div className="mb-12">
           <div className="mb-4 inline-flex items-center gap-2 rounded-full border border-primary/20 bg-primary/10 px-4 py-2 text-sm font-medium text-primary">
             <TagIcon className="h-4 w-4" />
-            <span>Tag</span>
+            <span>{tArticle('tag')}</span>
           </div>
 
           <h1 className="text-4xl font-bold text-foreground sm:text-5xl">
@@ -70,7 +87,7 @@ export default async function TagPage({ params }: TagPageProps) {
           </h1>
 
           <p className="mt-4 text-lg text-muted-foreground">
-            {posts.length} {posts.length === 1 ? 'article' : 'articles'} tagged with{' '}
+            {t('articlesTagged', { count: posts.length })}{' '}
             <span className="text-primary">{decodedTag}</span>
           </p>
         </div>
@@ -87,6 +104,8 @@ export default async function TagPage({ params }: TagPageProps) {
               readingTime={post.readingTime}
               tags={post.frontmatter.tags}
               image={post.frontmatter.coverImage}
+              availableLocales={post.availableLocales}
+              isFallback={post.isFallback}
             />
           ))}
         </div>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,86 +1,11 @@
-import type { Metadata } from "next"
-import { Lexend_Deca, Geist_Mono } from "next/font/google"
-import { Analytics } from "@vercel/analytics/react"
-import { ThemeProvider } from "@/components/layout/theme-provider"
-import { Header } from "@/components/layout/header"
-import { Footer } from "@/components/layout/footer"
-import { Search } from "@/components/search/search"
-import { siteConfig } from "@/lib/config"
 import "./globals.css"
 
-const lexend = Lexend_Deca({
-  variable: "--font-lexend",
-  subsets: ["latin"],
-  weight: ["300", "400", "600", "700"],
-})
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-})
-
-export const metadata: Metadata = {
-  title: {
-    default: siteConfig.name,
-    template: `%s | ${siteConfig.name}`,
-  },
-  description: siteConfig.description,
-  authors: [{ name: siteConfig.author.name }],
-  creator: siteConfig.author.name,
-  metadataBase: new URL(siteConfig.url),
-  openGraph: {
-    type: "website",
-    locale: "en_US",
-    url: siteConfig.url,
-    title: siteConfig.name,
-    description: siteConfig.description,
-    siteName: siteConfig.name,
-  },
-  twitter: {
-    card: "summary_large_image",
-    title: siteConfig.name,
-    description: siteConfig.description,
-    creator: siteConfig.author.twitter,
-  },
-  robots: {
-    index: true,
-    follow: true,
-    googleBot: {
-      index: true,
-      follow: true,
-      "max-video-preview": -1,
-      "max-image-preview": "large",
-      "max-snippet": -1,
-    },
-  },
-}
-
+// Root layout that just passes through to locale layout
+// All actual layout logic is in app/[locale]/layout.tsx
 export default function RootLayout({
   children,
-}: Readonly<{
+}: {
   children: React.ReactNode
-}>) {
-  return (
-    <html lang="en" suppressHydrationWarning>
-      <body
-        className={`${lexend.variable} ${geistMono.variable} font-sans antialiased`}
-      >
-        <ThemeProvider
-          attribute="class"
-          defaultTheme="dark"
-          enableSystem
-          disableTransitionOnChange
-        >
-          <Search>
-            <div className="flex min-h-screen flex-col">
-              <Header />
-              <main className="flex-1">{children}</main>
-              <Footer />
-            </div>
-          </Search>
-        </ThemeProvider>
-        <Analytics />
-      </body>
-    </html>
-  )
+}) {
+  return children
 }

--- a/app/pt-br/feed.xml/route.ts
+++ b/app/pt-br/feed.xml/route.ts
@@ -3,21 +3,21 @@ import { getAllPosts, getPostBySlug } from '@/lib/posts';
 import { siteConfig } from '@/lib/config';
 
 export async function GET() {
-  // English feed - only posts that have English content (not fallbacks)
-  const posts = getAllPosts('en').filter((p) => !p.isFallback);
+  // Portuguese feed - only posts that have Portuguese content (not fallbacks)
+  const posts = getAllPosts('pt-BR').filter((p) => !p.isFallback);
 
   const feed = new Feed({
     title: siteConfig.name,
     description: siteConfig.description,
-    id: siteConfig.url,
-    link: siteConfig.url,
-    language: 'en',
+    id: `${siteConfig.url}/pt-br`,
+    link: `${siteConfig.url}/pt-br`,
+    language: 'pt-BR',
     image: `${siteConfig.url}/logo.png`,
     favicon: `${siteConfig.url}/favicon.ico`,
-    copyright: `All rights reserved ${new Date().getFullYear()}, ${siteConfig.author.name}`,
+    copyright: `Todos os direitos reservados ${new Date().getFullYear()}, ${siteConfig.author.name}`,
     updated: posts[0] ? new Date(posts[0].frontmatter.date) : new Date(),
     feedLinks: {
-      rss2: `${siteConfig.url}/feed.xml`,
+      rss2: `${siteConfig.url}/pt-br/feed.xml`,
     },
     author: {
       name: siteConfig.author.name,
@@ -26,10 +26,10 @@ export async function GET() {
   });
 
   for (const postMeta of posts) {
-    const post = getPostBySlug(postMeta.slug, 'en');
-    if (!post) continue;
+    const post = getPostBySlug(postMeta.slug, 'pt-BR');
+    if (!post || post.isFallback) continue;
 
-    const url = `${siteConfig.url}/blog/${post.slug}`;
+    const url = `${siteConfig.url}/pt-br/blog/${post.slug}`;
 
     feed.addItem({
       title: post.frontmatter.title,

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,39 +1,73 @@
 import { MetadataRoute } from 'next';
-import { getAllPosts, getAllTags } from '@/lib/posts';
+import { getAllPosts, getAllTags, getAllSlugs, getAvailableLocales } from '@/lib/posts';
 import { siteConfig } from '@/lib/config';
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  const posts = getAllPosts();
+  const slugs = getAllSlugs();
   const tags = getAllTags();
 
-  const postUrls = posts.map((post) => ({
-    url: `${siteConfig.url}/blog/${post.slug}`,
-    lastModified: new Date(post.frontmatter.date),
-    changeFrequency: 'monthly' as const,
-    priority: 0.8,
-  }));
-
-  const tagUrls = tags.map(({ tag }) => ({
-    url: `${siteConfig.url}/tag/${encodeURIComponent(tag)}`,
-    lastModified: new Date(),
-    changeFrequency: 'weekly' as const,
-    priority: 0.5,
-  }));
-
-  return [
+  // Static pages with language alternates
+  const staticPages: MetadataRoute.Sitemap = [
     {
       url: siteConfig.url,
       lastModified: new Date(),
       changeFrequency: 'daily',
       priority: 1,
+      alternates: {
+        languages: {
+          en: siteConfig.url,
+          'pt-BR': `${siteConfig.url}/pt-br`,
+        },
+      },
     },
     {
       url: `${siteConfig.url}/blog`,
       lastModified: new Date(),
       changeFrequency: 'daily',
       priority: 0.9,
+      alternates: {
+        languages: {
+          en: `${siteConfig.url}/blog`,
+          'pt-BR': `${siteConfig.url}/pt-br/blog`,
+        },
+      },
     },
-    ...postUrls,
-    ...tagUrls,
   ];
+
+  // Blog posts with language alternates
+  const postUrls: MetadataRoute.Sitemap = slugs.flatMap((slug) => {
+    const post = getAllPosts('en').find((p) => p.slug === slug);
+    if (!post) return [];
+
+    return [
+      {
+        url: `${siteConfig.url}/blog/${slug}`,
+        lastModified: new Date(post.frontmatter.date),
+        changeFrequency: 'monthly' as const,
+        priority: 0.8,
+        alternates: {
+          languages: {
+            en: `${siteConfig.url}/blog/${slug}`,
+            'pt-BR': `${siteConfig.url}/pt-br/blog/${slug}`,
+          },
+        },
+      },
+    ];
+  });
+
+  // Tag pages with language alternates
+  const tagUrls: MetadataRoute.Sitemap = tags.map(({ tag }) => ({
+    url: `${siteConfig.url}/tag/${encodeURIComponent(tag)}`,
+    lastModified: new Date(),
+    changeFrequency: 'weekly' as const,
+    priority: 0.5,
+    alternates: {
+      languages: {
+        en: `${siteConfig.url}/tag/${encodeURIComponent(tag)}`,
+        'pt-BR': `${siteConfig.url}/pt-br/tag/${encodeURIComponent(tag)}`,
+      },
+    },
+  }));
+
+  return [...staticPages, ...postUrls, ...tagUrls];
 }

--- a/components/blog/article-card.tsx
+++ b/components/blog/article-card.tsx
@@ -1,8 +1,13 @@
+'use client';
+
 import Link from 'next/link';
 import Image from 'next/image';
 import { Calendar, Clock } from 'lucide-react';
+import { useLocale, useTranslations } from 'next-intl';
 import { Card } from '@/components/ui/card';
 import { TagBadge } from './tag-badge';
+import { getLocalizedPath, formatShortDate, Locale } from '@/lib/i18n';
+import { cn } from '@/lib/utils';
 
 interface ArticleCardProps {
   slug: string;
@@ -12,6 +17,8 @@ interface ArticleCardProps {
   readingTime: string;
   tags?: string[];
   image?: string;
+  availableLocales?: Locale[];
+  isFallback?: boolean;
 }
 
 export function ArticleCard({
@@ -22,9 +29,17 @@ export function ArticleCard({
   readingTime,
   tags = [],
   image,
+  availableLocales = ['en'],
+  isFallback = false,
 }: ArticleCardProps) {
+  const locale = useLocale() as Locale;
+  const t = useTranslations('languageBadge');
+
+  const href = getLocalizedPath(`/blog/${slug}`, locale);
+  const formattedDate = formatShortDate(date, locale);
+
   return (
-    <Link href={`/blog/${slug}`}>
+    <Link href={href}>
       <Card className="group overflow-hidden border-border bg-card backdrop-blur transition-all hover:border-primary/50 hover:bg-surface-hover hover:shadow-lg hover:shadow-primary/10">
         {image && (
           <div className="relative aspect-video w-full overflow-hidden">
@@ -37,14 +52,36 @@ export function ArticleCard({
           </div>
         )}
         <div className="p-6">
-          <div className="mb-3 flex flex-wrap gap-2">
+          <div className="mb-3 flex flex-wrap items-center gap-2">
             {tags.slice(0, 3).map((tag) => (
               <TagBadge key={tag} tag={tag} />
             ))}
+
+            {/* Language Badges */}
+            <div className="ml-auto flex gap-1">
+              {availableLocales.map((loc) => (
+                <span
+                  key={loc}
+                  className={cn(
+                    "rounded px-1.5 py-0.5 text-[10px] font-medium",
+                    loc === locale && !isFallback
+                      ? "bg-primary/20 text-primary"
+                      : "bg-muted text-muted-foreground"
+                  )}
+                >
+                  {loc === 'en' ? t('en') : t('ptBR')}
+                </span>
+              ))}
+            </div>
           </div>
 
           <h3 className="mb-2 text-xl font-bold text-foreground transition-colors group-hover:text-primary">
             {title}
+            {isFallback && (
+              <span className="ml-2 text-xs font-normal text-muted-foreground">
+                ({t('unavailable')})
+              </span>
+            )}
           </h3>
 
           <p className="mb-4 line-clamp-2 text-sm text-muted-foreground">{description}</p>
@@ -52,11 +89,7 @@ export function ArticleCard({
           <div className="flex items-center gap-4 text-xs text-muted-foreground">
             <div className="flex items-center gap-1">
               <Calendar className="h-3.5 w-3.5" />
-              <time dateTime={date}>{new Date(date).toLocaleDateString('en-US', {
-                year: 'numeric',
-                month: 'short',
-                day: 'numeric',
-              })}</time>
+              <time dateTime={date}>{formattedDate}</time>
             </div>
             <div className="flex items-center gap-1">
               <Clock className="h-3.5 w-3.5" />

--- a/components/blog/article-header.tsx
+++ b/components/blog/article-header.tsx
@@ -1,6 +1,11 @@
+'use client';
+
 import Image from 'next/image';
-import { Calendar, Clock, User } from 'lucide-react';
+import { Calendar, Clock, User, AlertCircle } from 'lucide-react';
+import { useLocale, useTranslations } from 'next-intl';
 import { TagBadge } from './tag-badge';
+import { formatDate, getLocalizedPath, Locale } from '@/lib/i18n';
+import { cn } from '@/lib/utils';
 
 interface ArticleHeaderProps {
   title: string;
@@ -9,6 +14,8 @@ interface ArticleHeaderProps {
   author?: string;
   tags?: string[];
   image?: string;
+  isFallback?: boolean;
+  availableLocales?: Locale[];
 }
 
 export function ArticleHeader({
@@ -18,10 +25,41 @@ export function ArticleHeader({
   author = 'Davi Giroux',
   tags = [],
   image,
+  isFallback = false,
+  availableLocales = ['en'],
 }: ArticleHeaderProps) {
+  const locale = useLocale() as Locale;
+  const t = useTranslations('languageBadge');
+  const formattedDate = formatDate(date, locale);
+
   return (
     <header className="mb-12">
+      {/* Fallback Notice */}
+      {isFallback && (
+        <div className="mb-6 flex items-center gap-2 rounded-lg border border-yellow-500/20 bg-yellow-500/10 px-4 py-3 text-sm text-yellow-600 dark:text-yellow-400">
+          <AlertCircle className="h-4 w-4 flex-shrink-0" />
+          <span>{t('unavailable')} - Showing English version</span>
+        </div>
+      )}
+
       <div className="mb-8">
+        {/* Language Badges */}
+        <div className="mb-4 flex gap-2">
+          {availableLocales.map((loc) => (
+            <span
+              key={loc}
+              className={cn(
+                "rounded px-2 py-1 text-xs font-medium",
+                loc === locale && !isFallback
+                  ? "bg-primary/20 text-primary"
+                  : "bg-muted text-muted-foreground"
+              )}
+            >
+              {loc === 'en' ? t('en') : t('ptBR')}
+            </span>
+          ))}
+        </div>
+
         <h1 className="mb-6 text-4xl font-bold text-foreground sm:text-5xl lg:text-6xl">
           {title}
         </h1>
@@ -36,13 +74,7 @@ export function ArticleHeader({
 
           <div className="flex items-center gap-2">
             <Calendar className="h-4 w-4" />
-            <time dateTime={date}>
-              {new Date(date).toLocaleDateString('en-US', {
-                year: 'numeric',
-                month: 'long',
-                day: 'numeric',
-              })}
-            </time>
+            <time dateTime={date}>{formattedDate}</time>
           </div>
 
           <div className="h-4 w-px bg-border" />
@@ -56,7 +88,11 @@ export function ArticleHeader({
         {tags.length > 0 && (
           <div className="mt-6 flex flex-wrap gap-2">
             {tags.map((tag) => (
-              <TagBadge key={tag} tag={tag} href={`/blog?tag=${encodeURIComponent(tag)}`} />
+              <TagBadge
+                key={tag}
+                tag={tag}
+                href={getLocalizedPath(`/tag/${encodeURIComponent(tag)}`, locale)}
+              />
             ))}
           </div>
         )}

--- a/components/blog/giscus-comments.tsx
+++ b/components/blog/giscus-comments.tsx
@@ -2,17 +2,17 @@
 
 import { useEffect, useRef } from 'react';
 import { useTheme } from 'next-themes';
+import { useLocale, useTranslations } from 'next-intl';
 
 interface GiscusCommentsProps {
   repo?: string;
   repoId?: string;
   category?: string;
   categoryId?: string;
-  mapping?: string;
+  slug?: string; // Use slug for consistent mapping across languages
   reactionsEnabled?: boolean;
   emitMetadata?: boolean;
   inputPosition?: 'top' | 'bottom';
-  lang?: string;
   loading?: 'lazy' | 'eager';
 }
 
@@ -21,15 +21,19 @@ export function GiscusComments({
   repoId = '',
   category = 'Announcements',
   categoryId = '',
-  mapping = 'pathname',
+  slug,
   reactionsEnabled = true,
   emitMetadata = false,
   inputPosition = 'bottom',
-  lang = 'en',
   loading = 'lazy',
 }: GiscusCommentsProps) {
   const ref = useRef<HTMLDivElement>(null);
   const { resolvedTheme } = useTheme();
+  const locale = useLocale();
+  const t = useTranslations('article');
+
+  // Map locale to Giscus supported languages
+  const giscusLang = locale === 'pt-BR' ? 'pt' : 'en';
 
   useEffect(() => {
     if (!ref.current || ref.current.hasChildNodes()) return;
@@ -62,13 +66,17 @@ export function GiscusComments({
     script.setAttribute('data-repo-id', repoId);
     script.setAttribute('data-category', category);
     script.setAttribute('data-category-id', categoryId);
-    script.setAttribute('data-mapping', mapping);
+    // Use 'specific' mapping with the English slug for shared discussions
+    script.setAttribute('data-mapping', slug ? 'specific' : 'pathname');
+    if (slug) {
+      script.setAttribute('data-term', slug);
+    }
     script.setAttribute('data-strict', '0');
     script.setAttribute('data-reactions-enabled', reactionsEnabled ? '1' : '0');
     script.setAttribute('data-emit-metadata', emitMetadata ? '1' : '0');
     script.setAttribute('data-input-position', inputPosition);
     script.setAttribute('data-theme', resolvedTheme === 'dark' ? 'dark' : 'light');
-    script.setAttribute('data-lang', lang);
+    script.setAttribute('data-lang', giscusLang);
     script.setAttribute('data-loading', loading);
     script.crossOrigin = 'anonymous';
     script.async = true;
@@ -79,12 +87,12 @@ export function GiscusComments({
     repoId,
     category,
     categoryId,
-    mapping,
+    slug,
     reactionsEnabled,
     emitMetadata,
     inputPosition,
     resolvedTheme,
-    lang,
+    giscusLang,
     loading,
   ]);
 
@@ -109,7 +117,7 @@ export function GiscusComments({
 
   return (
     <div className="mt-12">
-      <h2 className="mb-6 text-2xl font-bold text-foreground">Comments</h2>
+      <h2 className="mb-6 text-2xl font-bold text-foreground">{t('comments')}</h2>
       <div ref={ref} className="giscus" />
     </div>
   );

--- a/components/home/hero.tsx
+++ b/components/home/hero.tsx
@@ -1,8 +1,15 @@
+'use client';
+
 import Link from 'next/link';
+import { useLocale, useTranslations } from 'next-intl';
 import { ArrowRight, Sparkles } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { getLocalizedPath, Locale } from '@/lib/i18n';
 
 export function Hero() {
+  const locale = useLocale() as Locale;
+  const t = useTranslations('hero');
+
   return (
     <section className="relative overflow-hidden border-b border-border bg-gradient-to-b from-background via-background to-surface">
       {/* Background decoration */}
@@ -14,22 +21,21 @@ export function Hero() {
           {/* Badge */}
           <div className="mb-8 inline-flex items-center gap-2 rounded-full border border-primary/20 bg-primary/10 px-4 py-2 text-sm font-medium text-primary backdrop-blur">
             <Sparkles className="h-4 w-4" />
-            <span>Welcome to DevGiroux</span>
+            <span>{t('badge')}</span>
           </div>
 
           {/* Heading */}
           <h1 className="mb-6 text-4xl font-bold tracking-tight text-foreground sm:text-6xl lg:text-7xl">
-            Exploring Code,
+            {t('title1')}
             <br />
             <span className="bg-gradient-to-r from-cyan-400 to-teal-500 bg-clip-text text-transparent">
-              One Post at a Time
+              {t('title2')}
             </span>
           </h1>
 
           {/* Description */}
           <p className="mb-10 text-lg leading-relaxed text-muted-foreground sm:text-xl">
-            Dive into the world of web development, programming, and technology.
-            Join me on a journey of continuous learning and discovery.
+            {t('description')}
           </p>
 
           {/* CTA Buttons */}
@@ -39,8 +45,8 @@ export function Hero() {
               size="lg"
               className="bg-primary text-primary-foreground hover:bg-primary/90 shadow-lg shadow-primary/20"
             >
-              <Link href="/blog">
-                Explore Articles
+              <Link href={getLocalizedPath('/blog', locale)}>
+                {t('exploreArticles')}
                 <ArrowRight className="ml-2 h-4 w-4" />
               </Link>
             </Button>
@@ -52,7 +58,7 @@ export function Hero() {
               className="border-primary/20 hover:border-primary/50 hover:bg-primary/10"
             >
               <Link href="#latest">
-                Latest Posts
+                {t('latestPosts')}
               </Link>
             </Button>
           </div>
@@ -61,15 +67,15 @@ export function Hero() {
           <div className="mt-16 grid grid-cols-3 gap-8 border-t border-border pt-12">
             <div>
               <div className="text-3xl font-bold text-primary">50+</div>
-              <div className="mt-1 text-sm text-muted-foreground">Articles</div>
+              <div className="mt-1 text-sm text-muted-foreground">{t('articles')}</div>
             </div>
             <div>
               <div className="text-3xl font-bold text-primary">10+</div>
-              <div className="mt-1 text-sm text-muted-foreground">Topics</div>
+              <div className="mt-1 text-sm text-muted-foreground">{t('topics')}</div>
             </div>
             <div>
               <div className="text-3xl font-bold text-primary">1k+</div>
-              <div className="mt-1 text-sm text-muted-foreground">Readers</div>
+              <div className="mt-1 text-sm text-muted-foreground">{t('readers')}</div>
             </div>
           </div>
         </div>

--- a/components/layout/footer.tsx
+++ b/components/layout/footer.tsx
@@ -1,6 +1,10 @@
+'use client';
+
 import Link from "next/link"
+import { useLocale, useTranslations } from 'next-intl'
 import { Github, Twitter, Instagram, Youtube, Rss } from "lucide-react"
 import { siteConfig } from "@/lib/config"
+import { getLocalizedPath, Locale } from "@/lib/i18n"
 
 const socialLinks = [
   { href: siteConfig.links.twitter, icon: Twitter, label: "Twitter" },
@@ -10,7 +14,12 @@ const socialLinks = [
 ]
 
 export function Footer() {
+  const locale = useLocale() as Locale
+  const t = useTranslations('footer')
   const currentYear = new Date().getFullYear()
+
+  // RSS feed URL based on locale
+  const feedUrl = locale === 'pt-BR' ? '/pt-br/feed.xml' : '/feed.xml'
 
   return (
     <footer className="mt-auto border-t border-border">
@@ -18,7 +27,7 @@ export function Footer() {
         <div className="flex flex-col items-center justify-between gap-6 md:flex-row">
           <div className="flex flex-col items-center gap-2 md:items-start">
             <Link
-              href="/"
+              href={getLocalizedPath('/', locale)}
               className="text-lg font-semibold transition-colors hover:text-primary"
             >
               <span className="bg-gradient-to-r from-primary to-cyan-400 bg-clip-text text-transparent">
@@ -26,7 +35,7 @@ export function Footer() {
               </span>
             </Link>
             <p className="text-sm text-muted-foreground">
-              &copy; {currentYear} {siteConfig.author.name}. All rights reserved.
+              &copy; {currentYear} {siteConfig.author.name}. {t('copyright')}.
             </p>
           </div>
 
@@ -44,7 +53,7 @@ export function Footer() {
               </a>
             ))}
             <Link
-              href="/feed.xml"
+              href={feedUrl}
               className="text-muted-foreground transition-colors hover:text-primary"
               aria-label="RSS Feed"
             >

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -2,29 +2,58 @@
 
 import * as React from "react"
 import Link from "next/link"
-import { usePathname } from "next/navigation"
-import { Menu, X, Search } from "lucide-react"
+import { usePathname, useRouter } from "next/navigation"
+import { useLocale, useTranslations } from 'next-intl'
+import { Menu, X, Search, Globe } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
 import { ThemeToggle } from "./theme-toggle"
 import { siteConfig } from "@/lib/config"
 import { useSearch } from "@/components/search"
-
-const navItems = [
-  { href: "/", label: "Home" },
-  { href: "/blog", label: "Blog" },
-]
+import { getLocalizedPath, stripLocaleFromPath, Locale } from "@/lib/i18n"
 
 export function Header() {
   const pathname = usePathname()
+  const router = useRouter()
+  const locale = useLocale() as Locale
+  const t = useTranslations('nav')
+  const tLang = useTranslations('language')
+
   const [isMenuOpen, setIsMenuOpen] = React.useState(false)
   const { openSearch } = useSearch()
+
+  const navItems = [
+    { href: "/", label: t("home") },
+    { href: "/blog", label: t("blog") },
+  ]
+
+  // Switch language while staying on same page
+  const switchLocale = (newLocale: Locale) => {
+    const { path } = stripLocaleFromPath(pathname)
+    const newPath = getLocalizedPath(path, newLocale)
+    router.push(newPath)
+  }
+
+  // Get localized href
+  const getHref = (path: string) => getLocalizedPath(path, locale)
+
+  // Check if path is active
+  const isActive = (path: string) => {
+    const { path: currentPath } = stripLocaleFromPath(pathname)
+    return currentPath === path
+  }
 
   return (
     <header className="sticky top-0 z-50 w-full border-b border-border bg-background/80 backdrop-blur-md">
       <div className="container mx-auto flex h-16 max-w-4xl items-center justify-between px-4">
         <Link
-          href="/"
+          href={getHref("/")}
           className="flex items-center space-x-2 text-xl font-semibold transition-colors hover:text-primary"
         >
           <span className="bg-gradient-to-r from-primary to-cyan-400 bg-clip-text text-transparent">
@@ -37,10 +66,10 @@ export function Header() {
           {navItems.map((item) => (
             <Link
               key={item.href}
-              href={item.href}
+              href={getHref(item.href)}
               className={cn(
                 "px-4 py-2 text-sm font-light transition-colors hover:text-primary",
-                pathname === item.href
+                isActive(item.href)
                   ? "text-primary"
                   : "text-muted-foreground"
               )}
@@ -57,6 +86,35 @@ export function Header() {
             <Search className="h-4 w-4" />
             <span className="sr-only">Search</span>
           </Button>
+
+          {/* Language Switcher */}
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-9 w-9 transition-colors hover:bg-surface-hover"
+              >
+                <Globe className="h-4 w-4" />
+                <span className="sr-only">{tLang('switch')}</span>
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem
+                onClick={() => switchLocale('en')}
+                className={cn(locale === 'en' && 'bg-primary/10')}
+              >
+                {tLang('en')}
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onClick={() => switchLocale('pt-BR')}
+                className={cn(locale === 'pt-BR' && 'bg-primary/10')}
+              >
+                {tLang('ptBR')}
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+
           <ThemeToggle />
         </nav>
 
@@ -70,6 +128,34 @@ export function Header() {
           >
             <Search className="h-4 w-4" />
           </Button>
+
+          {/* Mobile Language Switcher */}
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-9 w-9"
+              >
+                <Globe className="h-4 w-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem
+                onClick={() => switchLocale('en')}
+                className={cn(locale === 'en' && 'bg-primary/10')}
+              >
+                {tLang('en')}
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onClick={() => switchLocale('pt-BR')}
+                className={cn(locale === 'pt-BR' && 'bg-primary/10')}
+              >
+                {tLang('ptBR')}
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+
           <ThemeToggle />
           <Button
             variant="ghost"
@@ -94,10 +180,10 @@ export function Header() {
             {navItems.map((item) => (
               <Link
                 key={item.href}
-                href={item.href}
+                href={getHref(item.href)}
                 className={cn(
                   "rounded-md px-4 py-2 text-sm font-light transition-colors hover:bg-surface-hover",
-                  pathname === item.href
+                  isActive(item.href)
                     ? "text-primary"
                     : "text-muted-foreground"
                 )}

--- a/content/posts/building-this-blog.en.mdx
+++ b/content/posts/building-this-blog.en.mdx
@@ -6,6 +6,7 @@ tags: ["nextjs", "tutorial", "web-development", "react", "tailwindcss"]
 coverImage: ""
 draft: false
 featured: true
+lang: "en"
 ---
 
 # How I Built This Blog with Next.js 15

--- a/content/posts/code-examples.en.mdx
+++ b/content/posts/code-examples.en.mdx
@@ -6,6 +6,7 @@ tags: ["code", "snippets", "reference", "typescript", "react"]
 coverImage: ""
 draft: false
 featured: false
+lang: "en"
 ---
 
 # Code Snippets and Examples

--- a/content/posts/welcome.en.mdx
+++ b/content/posts/welcome.en.mdx
@@ -6,6 +6,7 @@ tags: ["welcome", "personal", "introduction"]
 coverImage: ""
 draft: false
 featured: true
+lang: "en"
 ---
 
 # Welcome to DevGiroux!

--- a/docs/08-multi-language-support/README.md
+++ b/docs/08-multi-language-support/README.md
@@ -1,0 +1,580 @@
+# Multi-Language Support Specification
+
+This document defines the complete internationalization (i18n) implementation for the devgiroux blog, supporting English and Brazilian Portuguese.
+
+---
+
+## Overview
+
+| Aspect | Decision |
+|--------|----------|
+| Supported Languages | English (en), Brazilian Portuguese (pt-BR) |
+| Primary Language | English |
+| i18n Library | next-intl |
+| Extensibility | Optimized for two languages |
+
+> **Note:** The Portuguese variant used throughout this site is **Brazilian Portuguese (pt-BR)**, not European Portuguese (pt-PT). This affects spelling, vocabulary, and date formatting conventions.
+
+---
+
+## URL Structure
+
+### Routing Strategy
+
+- **English (primary):** No prefix — served at root `/`
+- **Brazilian Portuguese:** Prefixed with `/pt-br/`
+
+```
+English:  /blog/building-this-blog
+Portuguese: /pt-br/blog/building-this-blog
+```
+
+### Slug Handling
+
+Slugs remain **identical across languages**. The same slug is used regardless of language:
+
+```
+/blog/my-article        → English version
+/pt-br/blog/my-article  → Brazilian Portuguese version
+```
+
+### Invalid Locale Handling
+
+If a user requests an unsupported locale prefix (e.g., `/es/`, `/fr/`), redirect to the **English equivalent** of the requested path.
+
+---
+
+## Language Detection & Persistence
+
+### First-Time Visitors
+
+1. Read `Accept-Language` header from browser
+2. If Portuguese (`pt`, `pt-BR`) is preferred, redirect to `/pt-br/`
+3. Otherwise, serve English at root `/`
+
+> **Note:** European Portuguese (`pt-PT`) users will also be served Brazilian Portuguese content, as the differences are minor for a technical blog.
+
+### Returning Visitors
+
+- Store language preference in an **HttpOnly cookie** with 1-year expiration
+- Cookie takes precedence over browser detection on subsequent visits
+
+### Cookie Specification
+
+```
+Name: locale
+Value: "en" | "pt-BR"
+HttpOnly: true
+Secure: true (in production)
+SameSite: Lax
+Max-Age: 31536000 (1 year)
+Path: /
+```
+
+---
+
+## Content Management
+
+### File Structure
+
+Use **separate MDX files** per language with a naming convention:
+
+```
+content/posts/
+├── building-this-blog.en.mdx
+├── building-this-blog.pt-BR.mdx
+├── welcome.en.mdx
+├── welcome.pt-BR.mdx
+└── code-examples.en.mdx          ← No Portuguese version yet
+```
+
+### Frontmatter Schema
+
+```yaml
+---
+title: "Building This Blog"
+description: "A deep dive into the tech stack..."
+date: "2025-01-15"
+tags: ["nextjs", "mdx", "tutorial"]
+lang: "en"                    # Required: "en" | "pt-BR"
+---
+```
+
+**Note:** Metadata like `date`, `tags`, and `author` are **shared** across translations. Only `title`, `description`, and content differ.
+
+### Translation Fallback
+
+When a Portuguese translation does not exist:
+
+- **Behavior:** Display the English version
+- **No placeholder or stub** — content simply falls back to English
+- The language switcher should indicate the translation is unavailable
+
+### Code Blocks
+
+Code blocks remain **in English** regardless of article language:
+- Variable names stay in English
+- Comments stay in English
+- This follows universal developer conventions
+
+---
+
+## UI Translation
+
+### Translation Files
+
+Use JSON translation files for static UI copy:
+
+```
+locales/
+├── en.json
+└── pt-BR.json
+```
+
+### Structure Example
+
+```json
+// en.json
+{
+  "nav": {
+    "home": "Home",
+    "blog": "Blog",
+    "about": "About"
+  },
+  "search": {
+    "placeholder": "Search articles...",
+    "noResults": "No articles found"
+  },
+  "article": {
+    "readingTime": "{minutes} min read",
+    "publishedOn": "Published on {date}",
+    "shareArticle": "Share this article"
+  },
+  "errors": {
+    "notFound": "Page not found",
+    "notFoundDescription": "The page you're looking for doesn't exist."
+  },
+  "footer": {
+    "copyright": "All rights reserved"
+  }
+}
+```
+
+```json
+// pt-BR.json
+{
+  "nav": {
+    "home": "Início",
+    "blog": "Blog",
+    "about": "Sobre"
+  },
+  "search": {
+    "placeholder": "Buscar artigos...",
+    "noResults": "Nenhum artigo encontrado"
+  },
+  "article": {
+    "readingTime": "{minutes} min de leitura",
+    "publishedOn": "Publicado em {date}",
+    "shareArticle": "Compartilhar artigo"
+  },
+  "errors": {
+    "notFound": "Página não encontrada",
+    "notFoundDescription": "A página que você procura não existe."
+  },
+  "footer": {
+    "copyright": "Todos os direitos reservados"
+  }
+}
+```
+
+---
+
+## UI/UX Components
+
+### Language Switcher
+
+**Location:** Header navigation bar
+
+**Display:** Language codes (`EN` / `PT-BR`) or flags
+
+**Behavior:**
+1. Clicking switches to the same page in the other language
+2. If translation exists → navigate to translated version
+3. If translation doesn't exist → navigate but show fallback English content
+4. Updates the locale cookie
+
+### Translation Availability Badges
+
+**Location:** Article cards on listing pages
+
+**Display:** Small badge or icon indicating available languages
+
+```
+┌──────────────────────────────────┐
+│ Building This Blog               │
+│ A deep dive into...              │
+│                                  │
+│ Jan 15, 2025    [EN] [PT-BR]     │ ← Language badges
+└──────────────────────────────────┘
+```
+
+### Error Pages
+
+Error pages (404, 500) are **fully localized** in the current language.
+
+---
+
+## Date & Number Formatting
+
+### Full Localization
+
+Dates follow locale conventions:
+
+| English | Portuguese |
+|---------|------------|
+| December 31, 2025 | 31 de dezembro de 2025 |
+| Jan 15, 2025 | 15 jan. 2025 |
+
+Use `next-intl`'s formatting utilities:
+
+```tsx
+const formattedDate = format(date, 'MMMM d, yyyy', { locale: currentLocale });
+```
+
+### Reading Time
+
+Reading time is calculated from the **English version** only for consistency across languages.
+
+---
+
+## Search Functionality
+
+### Cross-Language Search
+
+Search returns results from **all languages** with clear labels:
+
+```
+Search: "nextjs"
+
+Results:
+────────────────────────────
+Building This Blog [EN]
+A deep dive into the Next.js...
+
+Construindo Este Blog [PT]
+Um mergulho profundo no Next.js...
+────────────────────────────
+```
+
+Each result displays a language indicator badge.
+
+---
+
+## Tags & Taxonomy
+
+### Unified English Tags
+
+Tags remain in English across all languages:
+
+- URL: `/tag/nextjs` (not `/pt/tag/nextjs`)
+- The tag page at `/tag/nextjs` shows posts in **both languages**
+- Tag display names are not translated
+
+This keeps the taxonomy simple and URLs consistent.
+
+---
+
+## RSS Feeds
+
+### Separate Feeds Per Language
+
+```
+/feed.xml         → English posts only
+/pt-br/feed.xml   → Brazilian Portuguese posts only
+```
+
+Each feed includes only posts in that language. If a post only exists in English, it appears only in `/feed.xml`.
+
+---
+
+## SEO Configuration
+
+### Sitemap
+
+**Single sitemap** with hreflang annotations:
+
+```xml
+<url>
+  <loc>https://devgiroux.com/blog/building-this-blog</loc>
+  <xhtml:link rel="alternate" hreflang="en"
+              href="https://devgiroux.com/blog/building-this-blog"/>
+  <xhtml:link rel="alternate" hreflang="pt-BR"
+              href="https://devgiroux.com/pt-br/blog/building-this-blog"/>
+  <xhtml:link rel="alternate" hreflang="x-default"
+              href="https://devgiroux.com/blog/building-this-blog"/>
+</url>
+```
+
+### Canonical URLs
+
+**Self-referencing canonicals** — each language version is canonical to itself:
+
+```html
+<!-- On /blog/my-article -->
+<link rel="canonical" href="https://devgiroux.com/blog/my-article" />
+
+<!-- On /pt-br/blog/my-article -->
+<link rel="canonical" href="https://devgiroux.com/pt-br/blog/my-article" />
+```
+
+### Hreflang Tags
+
+Every page includes hreflang link tags:
+
+```html
+<link rel="alternate" hreflang="en" href="https://devgiroux.com/blog/my-article" />
+<link rel="alternate" hreflang="pt-BR" href="https://devgiroux.com/pt-br/blog/my-article" />
+<link rel="alternate" hreflang="x-default" href="https://devgiroux.com/blog/my-article" />
+```
+
+### Open Graph Images
+
+OG images use **English text only** for brand consistency across social shares.
+
+### HTML Lang Attribute
+
+```html
+<html lang="en">  <!-- or "pt-BR" -->
+```
+
+---
+
+## Comments (Giscus)
+
+### Shared Discussions
+
+Both language versions of an article share the **same GitHub discussion thread**.
+
+**Mapping strategy:** Use the English slug as the discussion identifier regardless of current language.
+
+```tsx
+<Giscus
+  repo="devgiroux/blog-comments"
+  mapping="specific"
+  term={englishSlug}  // Always use English slug
+  // ...
+/>
+```
+
+This keeps the community unified rather than fragmenting discussions.
+
+---
+
+## Internal Linking
+
+### Language-Aware Links
+
+When linking between posts within MDX content, links automatically resolve to the same-language version:
+
+```markdown
+<!-- In English article -->
+Check out my [previous post](/blog/welcome)
+→ Links to /blog/welcome
+
+<!-- In Brazilian Portuguese article -->
+Veja meu [post anterior](/blog/welcome)
+→ Automatically resolves to /pt-br/blog/welcome
+```
+
+Implementation: Middleware or custom Link component that prepends locale when needed.
+
+---
+
+## MDX Components
+
+### Locale Prop Pattern
+
+MDX components receive the current locale and can adapt their display:
+
+```tsx
+interface CalloutProps {
+  type: 'info' | 'warning' | 'tip';
+  locale: 'en' | 'pt-BR';
+  children: React.ReactNode;
+}
+
+const labels = {
+  'en': { info: 'Info', warning: 'Warning', tip: 'Tip' },
+  'pt-BR': { info: 'Info', warning: 'Aviso', tip: 'Dica' }
+};
+
+function Callout({ type, locale, children }: CalloutProps) {
+  return (
+    <div className={`callout callout-${type}`}>
+      <span className="callout-label">{labels[locale][type]}</span>
+      {children}
+    </div>
+  );
+}
+```
+
+### Table of Contents
+
+TOC headings are **extracted from the translated content** — they automatically reflect the language of the current article.
+
+---
+
+## Homepage & Static Pages
+
+### Hero Section
+
+Same structure across languages, with translated text:
+
+| Element | English | Portuguese |
+|---------|---------|------------|
+| Headline | "Welcome to my blog" | "Bem-vindo ao meu blog" |
+| Tagline | "Thoughts on web development" | "Reflexões sobre desenvolvimento web" |
+| CTA | "Read Latest" | "Ler Mais Recente" |
+
+---
+
+## Technical Implementation
+
+### Next.js Configuration
+
+```ts
+// next.config.ts
+import createNextIntlPlugin from 'next-intl/plugin';
+
+const withNextIntl = createNextIntlPlugin();
+
+export default withNextIntl({
+  // existing config
+});
+```
+
+### Middleware
+
+```ts
+// middleware.ts
+import createMiddleware from 'next-intl/middleware';
+
+export default createMiddleware({
+  locales: ['en', 'pt-BR'],
+  defaultLocale: 'en',
+  localePrefix: 'as-needed'  // No prefix for default locale
+});
+
+export const config = {
+  matcher: ['/((?!api|_next|.*\\..*).*)']
+};
+```
+
+### App Directory Structure
+
+```
+app/
+├── [locale]/
+│   ├── layout.tsx
+│   ├── page.tsx
+│   ├── blog/
+│   │   ├── page.tsx
+│   │   └── [slug]/
+│   │       └── page.tsx
+│   ├── tag/
+│   │   └── [tag]/
+│   │       └── page.tsx
+│   └── not-found.tsx
+├── api/
+└── globals.css
+```
+
+### Provider Setup
+
+```tsx
+// app/[locale]/layout.tsx
+import { NextIntlClientProvider } from 'next-intl';
+import { getMessages } from 'next-intl/server';
+
+export default async function LocaleLayout({
+  children,
+  params: { locale }
+}: {
+  children: React.ReactNode;
+  params: { locale: string };
+}) {
+  const messages = await getMessages();
+
+  return (
+    <html lang={locale}>
+      <body>
+        <NextIntlClientProvider messages={messages}>
+          {children}
+        </NextIntlClientProvider>
+      </body>
+    </html>
+  );
+}
+```
+
+---
+
+## File Changes Summary
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `locales/en.json` | English UI translations |
+| `locales/pt-BR.json` | Brazilian Portuguese UI translations |
+| `middleware.ts` | Locale detection and routing |
+| `i18n.ts` | next-intl configuration |
+| `lib/i18n.ts` | Helper functions for i18n |
+
+### Modified Files
+
+| File | Changes |
+|------|---------|
+| `next.config.ts` | Add next-intl plugin |
+| `app/layout.tsx` | Move to `app/[locale]/layout.tsx` |
+| `app/page.tsx` | Move to `app/[locale]/page.tsx` |
+| `app/blog/*` | Move under `[locale]` segment |
+| `lib/posts.ts` | Add locale filtering logic |
+| `lib/mdx.ts` | Handle `.en.mdx` / `.pt-BR.mdx` files |
+| `components/layout/header.tsx` | Add language switcher |
+| `components/blog/article-card.tsx` | Add language badges |
+| `app/sitemap.ts` | Add hreflang annotations |
+| `app/feed.xml/route.ts` | Split into locale-specific feeds |
+
+### Content Migration
+
+Rename existing MDX files (keeping `.en.mdx` suffix for English, `.pt-BR.mdx` for Portuguese):
+
+```
+building-this-blog.mdx → building-this-blog.en.mdx
+welcome.mdx → welcome.en.mdx
+code-examples.mdx → code-examples.en.mdx
+```
+
+---
+
+## Implementation Checklist
+
+- [ ] Install and configure `next-intl`
+- [ ] Create middleware for locale detection
+- [ ] Restructure app directory under `[locale]`
+- [ ] Create translation JSON files
+- [ ] Update `lib/posts.ts` for locale-aware post fetching
+- [ ] Update `lib/mdx.ts` for new file naming convention (`.en.mdx` / `.pt-BR.mdx`)
+- [ ] Migrate existing MDX files to `.en.mdx` naming
+- [ ] Add language switcher to header
+- [ ] Add language badges to article cards
+- [ ] Update sitemap with hreflang
+- [ ] Split RSS feeds by locale
+- [ ] Update Giscus configuration
+- [ ] Implement locale-aware internal linking
+- [ ] Add locale prop to MDX components
+- [ ] Localize error pages
+- [ ] Update date formatting utilities
+- [ ] Test browser detection and cookie persistence
+- [ ] Verify SEO: hreflang, canonicals, structured data

--- a/i18n.ts
+++ b/i18n.ts
@@ -1,0 +1,20 @@
+import { getRequestConfig } from 'next-intl/server';
+
+export const locales = ['en', 'pt-BR'] as const;
+export type Locale = (typeof locales)[number];
+export const defaultLocale: Locale = 'en';
+
+export default getRequestConfig(async ({ requestLocale }) => {
+  // This typically corresponds to the `[locale]` segment
+  let locale = await requestLocale;
+
+  // Ensure that a valid locale is used
+  if (!locale || !locales.includes(locale as Locale)) {
+    locale = defaultLocale;
+  }
+
+  return {
+    locale,
+    messages: (await import(`./locales/${locale}.json`)).default,
+  };
+});

--- a/lib/i18n.ts
+++ b/lib/i18n.ts
@@ -1,0 +1,119 @@
+import { locales, defaultLocale, type Locale } from '@/i18n';
+
+export { locales, defaultLocale, type Locale };
+
+/**
+ * Check if a locale string is a valid supported locale
+ */
+export function isValidLocale(locale: string): locale is Locale {
+  return locales.includes(locale as Locale);
+}
+
+/**
+ * Get the URL path with locale prefix.
+ * English (default) has no prefix, Portuguese uses /pt-br/
+ */
+export function getLocalizedPath(path: string, locale: Locale): string {
+  // Normalize path to start with /
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+
+  if (locale === defaultLocale) {
+    return normalizedPath;
+  }
+
+  // Use lowercase for URL (pt-br instead of pt-BR)
+  const urlLocale = locale.toLowerCase();
+  return `/${urlLocale}${normalizedPath}`;
+}
+
+/**
+ * Extract locale and clean path from a URL path
+ */
+export function stripLocaleFromPath(path: string): { locale: Locale; path: string } {
+  for (const locale of locales) {
+    const urlLocale = locale.toLowerCase();
+    if (path.startsWith(`/${urlLocale}/`)) {
+      return {
+        locale,
+        path: path.replace(`/${urlLocale}`, '') || '/',
+      };
+    }
+    if (path === `/${urlLocale}`) {
+      return {
+        locale,
+        path: '/',
+      };
+    }
+  }
+  return { locale: defaultLocale, path };
+}
+
+/**
+ * Format date in long format for the given locale
+ * English: "December 31, 2025"
+ * Portuguese: "31 de dezembro de 2025"
+ */
+export function formatDate(date: string | Date, locale: Locale): string {
+  const d = typeof date === 'string' ? new Date(date) : date;
+
+  if (locale === 'pt-BR') {
+    return d.toLocaleDateString('pt-BR', {
+      day: 'numeric',
+      month: 'long',
+      year: 'numeric',
+    });
+  }
+
+  return d.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+}
+
+/**
+ * Format date in short format for article cards
+ * English: "Dec 31, 2025"
+ * Portuguese: "31 de dez. de 2025"
+ */
+export function formatShortDate(date: string | Date, locale: Locale): string {
+  const d = typeof date === 'string' ? new Date(date) : date;
+
+  if (locale === 'pt-BR') {
+    return d.toLocaleDateString('pt-BR', {
+      day: 'numeric',
+      month: 'short',
+      year: 'numeric',
+    });
+  }
+
+  return d.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+/**
+ * Get the alternate locale (for language switcher)
+ */
+export function getAlternateLocale(locale: Locale): Locale {
+  return locale === 'en' ? 'pt-BR' : 'en';
+}
+
+/**
+ * Map locale to URL segment
+ */
+export function localeToUrlSegment(locale: Locale): string {
+  return locale.toLowerCase();
+}
+
+/**
+ * Map URL segment to locale
+ */
+export function urlSegmentToLocale(segment: string): Locale | null {
+  const normalized = segment.toLowerCase();
+  if (normalized === 'en') return 'en';
+  if (normalized === 'pt-br') return 'pt-BR';
+  return null;
+}

--- a/lib/posts.ts
+++ b/lib/posts.ts
@@ -2,8 +2,17 @@ import fs from "fs"
 import path from "path"
 import matter from "gray-matter"
 import readingTime from "reading-time"
+import { Locale, defaultLocale, locales } from "@/lib/i18n"
 
 const postsDirectory = path.join(process.cwd(), "content/posts")
+
+// Cache for file system operations (cleared on file changes in dev via HMR)
+const cache = {
+  baseSlugs: null as string[] | null,
+  availableLocales: new Map<string, Locale[]>(),
+  posts: new Map<string, Post | null>(),
+  readingTimes: new Map<string, string>(),
+}
 
 export interface PostFrontmatter {
   title: string
@@ -13,6 +22,7 @@ export interface PostFrontmatter {
   coverImage?: string
   draft?: boolean
   featured?: boolean
+  lang?: Locale
 }
 
 export interface Post {
@@ -20,58 +30,182 @@ export interface Post {
   frontmatter: PostFrontmatter
   content: string
   readingTime: string
+  availableLocales: Locale[]
+  isFallback: boolean
 }
 
 export interface PostMeta {
   slug: string
   frontmatter: PostFrontmatter
   readingTime: string
+  availableLocales: Locale[]
+  isFallback: boolean
 }
 
-function getMDXFiles(): string[] {
+/**
+ * Get all unique base slugs (without locale suffix)
+ * Handles both old format (slug.mdx) and new format (slug.locale.mdx)
+ */
+function getAllBaseSlugs(): string[] {
+  if (cache.baseSlugs) {
+    return cache.baseSlugs
+  }
+
   if (!fs.existsSync(postsDirectory)) {
+    cache.baseSlugs = []
     return []
   }
-  return fs.readdirSync(postsDirectory).filter((file) => file.endsWith(".mdx"))
+
+  const files = fs.readdirSync(postsDirectory).filter((file) => file.endsWith(".mdx"))
+  const slugs = new Set<string>()
+
+  for (const file of files) {
+    // Match: slug.mdx, slug.en.mdx, or slug.pt-BR.mdx
+    const match = file.match(/^(.+?)(?:\.(en|pt-BR))?\.mdx$/)
+    if (match) {
+      slugs.add(match[1])
+    }
+  }
+
+  cache.baseSlugs = Array.from(slugs)
+  return cache.baseSlugs
 }
 
-export function getPostBySlug(slug: string): Post | null {
-  const filePath = path.join(postsDirectory, `${slug}.mdx`)
+/**
+ * Get available locales for a given slug
+ */
+export function getAvailableLocales(slug: string): Locale[] {
+  if (cache.availableLocales.has(slug)) {
+    return cache.availableLocales.get(slug)!
+  }
 
+  const available: Locale[] = []
+
+  for (const locale of locales) {
+    const filePath = path.join(postsDirectory, `${slug}.${locale}.mdx`)
+    if (fs.existsSync(filePath)) {
+      available.push(locale)
+    }
+  }
+
+  // Check for old format (without locale suffix) - treat as English
+  if (available.length === 0) {
+    const oldFormatPath = path.join(postsDirectory, `${slug}.mdx`)
+    if (fs.existsSync(oldFormatPath)) {
+      available.push("en")
+    }
+  }
+
+  cache.availableLocales.set(slug, available)
+  return available
+}
+
+/**
+ * Get post file path with fallback logic
+ * Returns null if no file found
+ */
+function getPostFilePath(
+  slug: string,
+  locale: Locale
+): { path: string; isFallback: boolean } | null {
+  // Try requested locale first (new format)
+  const localizedPath = path.join(postsDirectory, `${slug}.${locale}.mdx`)
+  if (fs.existsSync(localizedPath)) {
+    return { path: localizedPath, isFallback: false }
+  }
+
+  // Fallback to English if requesting non-default locale
+  if (locale !== defaultLocale) {
+    const fallbackPath = path.join(postsDirectory, `${slug}.${defaultLocale}.mdx`)
+    if (fs.existsSync(fallbackPath)) {
+      return { path: fallbackPath, isFallback: true }
+    }
+  }
+
+  // Try old format (without locale suffix) as final fallback
+  const oldFormatPath = path.join(postsDirectory, `${slug}.mdx`)
+  if (fs.existsSync(oldFormatPath)) {
+    return { path: oldFormatPath, isFallback: locale !== defaultLocale }
+  }
+
+  return null
+}
+
+/**
+ * Get reading time from English version for consistency across locales
+ */
+function getEnglishReadingTime(slug: string): string {
+  if (cache.readingTimes.has(slug)) {
+    return cache.readingTimes.get(slug)!
+  }
+
+  const enPath = path.join(postsDirectory, `${slug}.en.mdx`)
+  const oldPath = path.join(postsDirectory, `${slug}.mdx`)
+
+  const filePath = fs.existsSync(enPath) ? enPath : oldPath
   if (!fs.existsSync(filePath)) {
+    cache.readingTimes.set(slug, "1 min read")
+    return "1 min read"
+  }
+
+  const content = fs.readFileSync(filePath, "utf-8")
+  const { content: mdxContent } = matter(content)
+  const time = readingTime(mdxContent).text
+
+  cache.readingTimes.set(slug, time)
+  return time
+}
+
+/**
+ * Get a single post by slug and locale
+ */
+export function getPostBySlug(slug: string, locale: Locale = defaultLocale): Post | null {
+  const fileInfo = getPostFilePath(slug, locale)
+  if (!fileInfo) {
     return null
   }
 
-  const fileContent = fs.readFileSync(filePath, "utf-8")
+  const fileContent = fs.readFileSync(fileInfo.path, "utf-8")
   const { data, content } = matter(fileContent)
-  const stats = readingTime(content)
+  const availableLocales = getAvailableLocales(slug)
+
+  // Use English reading time for consistency
+  const readingTimeText = getEnglishReadingTime(slug)
 
   return {
     slug,
-    frontmatter: data as PostFrontmatter,
+    frontmatter: {
+      ...data,
+      lang: fileInfo.isFallback ? defaultLocale : locale,
+    } as PostFrontmatter,
     content,
-    readingTime: stats.text,
+    readingTime: readingTimeText,
+    availableLocales,
+    isFallback: fileInfo.isFallback,
   }
 }
 
-export function getAllPosts(): PostMeta[] {
-  const files = getMDXFiles()
+/**
+ * Get all posts for a specific locale
+ * Falls back to English for posts without translations
+ */
+export function getAllPosts(locale: Locale = defaultLocale): PostMeta[] {
+  const slugs = getAllBaseSlugs()
 
-  const posts = files
-    .map((file) => {
-      const slug = file.replace(".mdx", "")
-      const filePath = path.join(postsDirectory, file)
-      const fileContent = fs.readFileSync(filePath, "utf-8")
-      const { data, content } = matter(fileContent)
-      const stats = readingTime(content)
+  const posts = slugs
+    .map((slug) => {
+      const post = getPostBySlug(slug, locale)
+      if (!post) return null
 
       return {
-        slug,
-        frontmatter: data as PostFrontmatter,
-        readingTime: stats.text,
+        slug: post.slug,
+        frontmatter: post.frontmatter,
+        readingTime: post.readingTime,
+        availableLocales: post.availableLocales,
+        isFallback: post.isFallback,
       }
     })
-    .filter((post) => !post.frontmatter.draft)
+    .filter((post): post is PostMeta => post !== null && !post.frontmatter.draft)
     .sort((a, b) => {
       return new Date(b.frontmatter.date).getTime() - new Date(a.frontmatter.date).getTime()
     })
@@ -79,44 +213,103 @@ export function getAllPosts(): PostMeta[] {
   return posts
 }
 
-export function getFeaturedPosts(): PostMeta[] {
-  return getAllPosts()
+/**
+ * Get all posts from all locales (for cross-language search)
+ * Does not include fallback duplicates
+ */
+export function getAllPostsAllLocales(): (PostMeta & { locale: Locale })[] {
+  const slugs = getAllBaseSlugs()
+  const allPosts: (PostMeta & { locale: Locale })[] = []
+
+  for (const slug of slugs) {
+    const availableLocales = getAvailableLocales(slug)
+
+    for (const locale of availableLocales) {
+      const post = getPostBySlug(slug, locale)
+      if (post && !post.frontmatter.draft && !post.isFallback) {
+        allPosts.push({
+          slug: post.slug,
+          frontmatter: post.frontmatter,
+          readingTime: post.readingTime,
+          availableLocales: post.availableLocales,
+          isFallback: post.isFallback,
+          locale,
+        })
+      }
+    }
+  }
+
+  return allPosts.sort(
+    (a, b) => new Date(b.frontmatter.date).getTime() - new Date(a.frontmatter.date).getTime()
+  )
+}
+
+/**
+ * Get featured posts for a locale
+ */
+export function getFeaturedPosts(locale: Locale = defaultLocale): PostMeta[] {
+  return getAllPosts(locale)
     .filter((post) => post.frontmatter.featured)
     .slice(0, 3)
 }
 
-export function getLatestPosts(count: number = 5): PostMeta[] {
-  return getAllPosts().slice(0, count)
+/**
+ * Get latest posts for a locale
+ */
+export function getLatestPosts(count: number = 5, locale: Locale = defaultLocale): PostMeta[] {
+  return getAllPosts(locale).slice(0, count)
 }
 
-export function getPostsByTag(tag: string): PostMeta[] {
-  return getAllPosts().filter((post) =>
+/**
+ * Get posts by tag for a locale
+ * Tags remain unified (English) across all languages
+ */
+export function getPostsByTag(tag: string, locale: Locale = defaultLocale): PostMeta[] {
+  return getAllPosts(locale).filter((post) =>
     post.frontmatter.tags.map((t) => t.toLowerCase()).includes(tag.toLowerCase())
   )
 }
 
+/**
+ * Get all tags with counts
+ * Tags are unified across all languages, counting unique slugs
+ */
 export function getAllTags(): { tag: string; count: number }[] {
-  const posts = getAllPosts()
-  const tagMap = new Map<string, number>()
+  const slugs = getAllBaseSlugs()
+  const tagMap = new Map<string, Set<string>>()
 
-  posts.forEach((post) => {
+  for (const slug of slugs) {
+    const post = getPostBySlug(slug, "en")
+    if (!post || post.frontmatter.draft) continue
+
     post.frontmatter.tags.forEach((tag) => {
       const normalizedTag = tag.toLowerCase()
-      tagMap.set(normalizedTag, (tagMap.get(normalizedTag) || 0) + 1)
+      if (!tagMap.has(normalizedTag)) {
+        tagMap.set(normalizedTag, new Set())
+      }
+      tagMap.get(normalizedTag)!.add(slug)
     })
-  })
+  }
 
   return Array.from(tagMap.entries())
-    .map(([tag, count]) => ({ tag, count }))
+    .map(([tag, slugSet]) => ({ tag, count: slugSet.size }))
     .sort((a, b) => b.count - a.count)
 }
 
+/**
+ * Get all unique slugs
+ */
 export function getAllSlugs(): string[] {
-  return getMDXFiles().map((file) => file.replace(".mdx", ""))
+  return getAllBaseSlugs()
 }
 
-export function searchPosts(query: string): PostMeta[] {
-  const posts = getAllPosts()
+/**
+ * Search posts by query
+ * If locale is specified, searches only that locale
+ * Otherwise searches all posts
+ */
+export function searchPosts(query: string, locale?: Locale): PostMeta[] {
+  const posts = locale ? getAllPosts(locale) : getAllPosts()
   const lowerQuery = query.toLowerCase()
 
   return posts.filter((post) => {

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,0 +1,80 @@
+{
+  "nav": {
+    "home": "Home",
+    "blog": "Blog"
+  },
+  "hero": {
+    "badge": "Welcome to DevGiroux",
+    "title1": "Exploring Code,",
+    "title2": "One Post at a Time",
+    "description": "Dive into the world of web development, programming, and technology. Join me on a journey of continuous learning and discovery.",
+    "exploreArticles": "Explore Articles",
+    "latestPosts": "Latest Posts",
+    "articles": "Articles",
+    "topics": "Topics",
+    "readers": "Readers"
+  },
+  "sections": {
+    "featuredArticles": "Featured Articles",
+    "featuredDescription": "Handpicked posts you shouldn't miss",
+    "latestArticles": "Latest Articles",
+    "latestDescription": "Fresh insights and tutorials",
+    "viewAll": "View all",
+    "viewAllArticles": "View all articles",
+    "exploreByTopic": "Explore by Topic",
+    "browseByCategory": "Browse articles by category"
+  },
+  "blog": {
+    "title": "Blog",
+    "description": "Articles about web development, programming, and technology.",
+    "articlesCount": "{count} articles published",
+    "noPostsYet": "No posts yet",
+    "checkBackSoon": "Check back soon for new content!"
+  },
+  "article": {
+    "minRead": "{minutes} min read",
+    "publishedOn": "Published on {date}",
+    "shareArticle": "Share this article",
+    "comments": "Comments",
+    "backToBlog": "Back to Blog",
+    "tableOfContents": "Table of Contents",
+    "onThisPage": "On this page"
+  },
+  "tag": {
+    "title": "Tag: {tag}",
+    "articlesTagged": "{count} articles tagged with"
+  },
+  "search": {
+    "placeholder": "Search posts...",
+    "startTyping": "Start typing to search posts...",
+    "navigationHint": "Use arrows to navigate, Enter to select, Esc to close",
+    "noResults": "No posts found for \"{query}\"",
+    "tryDifferent": "Try different keywords or check your spelling",
+    "results": "{count} results"
+  },
+  "language": {
+    "switch": "Switch language",
+    "en": "English",
+    "ptBR": "Português (BR)"
+  },
+  "languageBadge": {
+    "en": "EN",
+    "ptBR": "PT-BR",
+    "unavailable": "Translation unavailable"
+  },
+  "errors": {
+    "notFound": "Page not found",
+    "notFoundDescription": "The page you're looking for doesn't exist.",
+    "backHome": "Back to home"
+  },
+  "footer": {
+    "copyright": "All rights reserved",
+    "builtWith": "Built with"
+  },
+  "share": {
+    "twitter": "Share on Twitter",
+    "linkedin": "Share on LinkedIn",
+    "copyLink": "Copy link",
+    "copied": "Copied!"
+  }
+}

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -1,0 +1,80 @@
+{
+  "nav": {
+    "home": "Início",
+    "blog": "Blog"
+  },
+  "hero": {
+    "badge": "Bem-vindo ao DevGiroux",
+    "title1": "Explorando Código,",
+    "title2": "Um Post de Cada Vez",
+    "description": "Mergulhe no mundo do desenvolvimento web, programação e tecnologia. Junte-se a mim em uma jornada de aprendizado e descoberta contínua.",
+    "exploreArticles": "Explorar Artigos",
+    "latestPosts": "Posts Recentes",
+    "articles": "Artigos",
+    "topics": "Tópicos",
+    "readers": "Leitores"
+  },
+  "sections": {
+    "featuredArticles": "Artigos em Destaque",
+    "featuredDescription": "Posts selecionados que você não pode perder",
+    "latestArticles": "Artigos Recentes",
+    "latestDescription": "Novos insights e tutoriais",
+    "viewAll": "Ver todos",
+    "viewAllArticles": "Ver todos os artigos",
+    "exploreByTopic": "Explorar por Tópico",
+    "browseByCategory": "Navegar artigos por categoria"
+  },
+  "blog": {
+    "title": "Blog",
+    "description": "Artigos sobre desenvolvimento web, programação e tecnologia.",
+    "articlesCount": "{count} artigos publicados",
+    "noPostsYet": "Nenhum post ainda",
+    "checkBackSoon": "Volte em breve para novos conteúdos!"
+  },
+  "article": {
+    "minRead": "{minutes} min de leitura",
+    "publishedOn": "Publicado em {date}",
+    "shareArticle": "Compartilhar artigo",
+    "comments": "Comentários",
+    "backToBlog": "Voltar ao Blog",
+    "tableOfContents": "Índice",
+    "onThisPage": "Nesta página"
+  },
+  "tag": {
+    "title": "Tag: {tag}",
+    "articlesTagged": "{count} artigos marcados com"
+  },
+  "search": {
+    "placeholder": "Buscar posts...",
+    "startTyping": "Comece a digitar para buscar posts...",
+    "navigationHint": "Use as setas para navegar, Enter para selecionar, Esc para fechar",
+    "noResults": "Nenhum post encontrado para \"{query}\"",
+    "tryDifferent": "Tente palavras-chave diferentes ou verifique a ortografia",
+    "results": "{count} resultados"
+  },
+  "language": {
+    "switch": "Trocar idioma",
+    "en": "English",
+    "ptBR": "Português (BR)"
+  },
+  "languageBadge": {
+    "en": "EN",
+    "ptBR": "PT-BR",
+    "unavailable": "Tradução indisponível"
+  },
+  "errors": {
+    "notFound": "Página não encontrada",
+    "notFoundDescription": "A página que você procura não existe.",
+    "backHome": "Voltar ao início"
+  },
+  "footer": {
+    "copyright": "Todos os direitos reservados",
+    "builtWith": "Feito com"
+  },
+  "share": {
+    "twitter": "Compartilhar no Twitter",
+    "linkedin": "Compartilhar no LinkedIn",
+    "copyLink": "Copiar link",
+    "copied": "Copiado!"
+  }
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,10 @@
 import type { NextConfig } from "next";
+import createNextIntlPlugin from 'next-intl/plugin';
+
+const withNextIntl = createNextIntlPlugin('./i18n.ts');
 
 const nextConfig: NextConfig = {
   pageExtensions: ['js', 'jsx', 'ts', 'tsx', 'md', 'mdx'],
 };
 
-export default nextConfig;
+export default withNextIntl(nextConfig);

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "gray-matter": "^4.0.3",
         "lucide-react": "^0.562.0",
         "next": "16.1.1",
+        "next-intl": "^4.6.1",
         "next-mdx-remote": "^5.0.0",
         "next-themes": "^0.4.6",
         "react": "19.2.3",
@@ -508,6 +509,66 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
       "license": "MIT"
+    },
+    "node_modules/@formatjs/ecma402-abstract": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.6.tgz",
+      "integrity": "sha512-HJnTFeRM2kVFVr5gr5kH1XP6K0JcJtE7Lzvtr3FS/so5f1kpsqqqxy5JF+FRaO6H2qmcMfAUIox7AJteieRtVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/intl-localematcher": "0.6.2",
+        "decimal.js": "^10.4.3",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/ecma402-abstract/node_modules/@formatjs/intl-localematcher": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.2.tgz",
+      "integrity": "sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/fast-memoize": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
+      "integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.4.tgz",
+      "integrity": "sha512-7kR78cRrPNB4fjGFZg3Rmj5aah8rQj9KPzuLsmcSn4ipLXQvC04keycTI1F7kJYDwIXtT2+7IDEto842CfZBtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.6",
+        "@formatjs/icu-skeleton-parser": "1.8.16",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "1.8.16",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.16.tgz",
+      "integrity": "sha512-H13E9Xl+PxBd8D5/6TVUluSpxGNvFSlN/b3coUp0e0JpuWXXnQDiavIpY3NnvSp4xhEMoXyyBvVfdFX8jglOHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.6",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/intl-localematcher": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.5.10.tgz",
+      "integrity": "sha512-af3qATX+m4Rnd9+wHcjJ4w2ijq+rAVP3CCinJQvFv1kgSu1W6jypUmvleJxcewdxmutM8dmIRZFxO/IQBZmP2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2"
+      }
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
@@ -1336,6 +1397,313 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@parcel/watcher": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.1.tgz",
+      "integrity": "sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^1.0.3",
+        "is-glob": "^4.0.3",
+        "micromatch": "^4.0.5",
+        "node-addon-api": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher-android-arm64": "2.5.1",
+        "@parcel/watcher-darwin-arm64": "2.5.1",
+        "@parcel/watcher-darwin-x64": "2.5.1",
+        "@parcel/watcher-freebsd-x64": "2.5.1",
+        "@parcel/watcher-linux-arm-glibc": "2.5.1",
+        "@parcel/watcher-linux-arm-musl": "2.5.1",
+        "@parcel/watcher-linux-arm64-glibc": "2.5.1",
+        "@parcel/watcher-linux-arm64-musl": "2.5.1",
+        "@parcel/watcher-linux-x64-glibc": "2.5.1",
+        "@parcel/watcher-linux-x64-musl": "2.5.1",
+        "@parcel/watcher-win32-arm64": "2.5.1",
+        "@parcel/watcher-win32-ia32": "2.5.1",
+        "@parcel/watcher-win32-x64": "2.5.1"
+      }
+    },
+    "node_modules/@parcel/watcher-android-arm64": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.1.tgz",
+      "integrity": "sha512-KF8+j9nNbUN8vzOFDpRMsaKBHZ/mcjEjMToVMJOhTozkDonQFFrRcfdLWn6yWKCmJKmdVxSgHiYvTCef4/qcBA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-arm64": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.1.tgz",
+      "integrity": "sha512-eAzPv5osDmZyBhou8PoF4i6RQXAfeKL9tjb3QzYuccXFMQU0ruIc/POh30ePnaOyD1UXdlKguHBmsTs53tVoPw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-x64": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.1.tgz",
+      "integrity": "sha512-1ZXDthrnNmwv10A0/3AJNZ9JGlzrF82i3gNQcWOzd7nJ8aj+ILyW1MTxVk35Db0u91oD5Nlk9MBiujMlwmeXZg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-freebsd-x64": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.1.tgz",
+      "integrity": "sha512-SI4eljM7Flp9yPuKi8W0ird8TI/JK6CSxju3NojVI6BjHsTyK7zxA9urjVjEKJ5MBYC+bLmMcbAWlZ+rFkLpJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-glibc": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.1.tgz",
+      "integrity": "sha512-RCdZlEyTs8geyBkkcnPWvtXLY44BCeZKmGYRtSgtwwnHR4dxfHRG3gR99XdMEdQ7KeiDdasJwwvNSF5jKtDwdA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-musl": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.1.tgz",
+      "integrity": "sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-glibc": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.1.tgz",
+      "integrity": "sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-musl": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.1.tgz",
+      "integrity": "sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-glibc": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.1.tgz",
+      "integrity": "sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-musl": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.1.tgz",
+      "integrity": "sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-arm64": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.1.tgz",
+      "integrity": "sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-ia32": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.1.tgz",
+      "integrity": "sha512-c2KkcVN+NJmuA7CGlaGD1qJh1cLfDnQsHjE89E60vUEMlqduHGCdCLJCID5geFVM0dOtA3ZiIO8BoEQmzQVfpQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-x64": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.1.tgz",
+      "integrity": "sha512-9lHBdJITeNR++EvSQVUcaZoWupyHfXe1jZvGZ06O/5MflPcuPLtEphScIBL+AiCWBO46tDSHzWyD0uDmmZqsgA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher/node_modules/detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "detect-libc": "bin/detect-libc.js"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/@radix-ui/primitive": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
@@ -1993,6 +2361,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@schummar/icu-type-parser": {
+      "version": "1.21.5",
+      "resolved": "https://registry.npmjs.org/@schummar/icu-type-parser/-/icu-type-parser-1.21.5.tgz",
+      "integrity": "sha512-bXHSaW5jRTmke9Vd0h5P7BtWZG9Znqb8gSDxZnxaGSJnGwPLDPfS+3g0BKzeWqzgZPsIVZkM7m2tbo18cm5HBw==",
+      "license": "MIT"
+    },
     "node_modules/@shikijs/core": {
       "version": "3.20.0",
       "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.20.0.tgz",
@@ -2076,6 +2450,172 @@
         "node": ">= 8.0.0"
       }
     },
+    "node_modules/@swc/core-darwin-arm64": {
+      "version": "1.15.8",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.8.tgz",
+      "integrity": "sha512-M9cK5GwyWWRkRGwwCbREuj6r8jKdES/haCZ3Xckgkl8MUQJZA3XB7IXXK1IXRNeLjg6m7cnoMICpXv1v1hlJOg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-darwin-x64": {
+      "version": "1.15.8",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.8.tgz",
+      "integrity": "sha512-j47DasuOvXl80sKJHSi2X25l44CMc3VDhlJwA7oewC1nV1VsSzwX+KOwE5tLnfORvVJJyeiXgJORNYg4jeIjYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm-gnueabihf": {
+      "version": "1.15.8",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.8.tgz",
+      "integrity": "sha512-siAzDENu2rUbwr9+fayWa26r5A9fol1iORG53HWxQL1J8ym4k7xt9eME0dMPXlYZDytK5r9sW8zEA10F2U3Xwg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-gnu": {
+      "version": "1.15.8",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.8.tgz",
+      "integrity": "sha512-o+1y5u6k2FfPYbTRUPvurwzNt5qd0NTumCTFscCNuBksycloXY16J8L+SMW5QRX59n4Hp9EmFa3vpvNHRVv1+Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-musl": {
+      "version": "1.15.8",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.8.tgz",
+      "integrity": "sha512-koiCqL09EwOP1S2RShCI7NbsQuG6r2brTqUYE7pV7kZm9O17wZ0LSz22m6gVibpwEnw8jI3IE1yYsQTVpluALw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-gnu": {
+      "version": "1.15.8",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.8.tgz",
+      "integrity": "sha512-4p6lOMU3bC+Vd5ARtKJ/FxpIC5G8v3XLoPEZ5s7mLR8h7411HWC/LmTXDHcrSXRC55zvAVia1eldy6zDLz8iFQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-musl": {
+      "version": "1.15.8",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.8.tgz",
+      "integrity": "sha512-z3XBnbrZAL+6xDGAhJoN4lOueIxC/8rGrJ9tg+fEaeqLEuAtHSW2QHDHxDwkxZMjuF/pZ6MUTjHjbp8wLbuRLA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-arm64-msvc": {
+      "version": "1.15.8",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.8.tgz",
+      "integrity": "sha512-djQPJ9Rh9vP8GTS/Df3hcc6XP6xnG5c8qsngWId/BLA9oX6C7UzCPAn74BG/wGb9a6j4w3RINuoaieJB3t+7iQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-ia32-msvc": {
+      "version": "1.15.8",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.8.tgz",
+      "integrity": "sha512-/wfAgxORg2VBaUoFdytcVBVCgf1isWZIEXB9MZEUty4wwK93M/PxAkjifOho9RN3WrM3inPLabICRCEgdHpKKQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-x64-msvc": {
+      "version": "1.15.8",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.8.tgz",
+      "integrity": "sha512-GpMePrh9Sl4d61o4KAHOOv5is5+zt6BEXCOCgs/H0FLGeii7j9bWDE8ExvKFy2GRRZVNR1ugsnzaGWHKM6kuzA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/counter": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -2083,6 +2623,15 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@swc/types": {
+      "version": "0.1.25",
+      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.25.tgz",
+      "integrity": "sha512-iAoY/qRhNH8a/hBvm3zKj9qQ4oc2+3w1unPJa2XvTK3XjeLXtzcCingVPw/9e5mn1+0yPqxcBGp9Jf0pkfMb1g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3"
       }
     },
     "node_modules/@tailwindcss/node": {
@@ -3420,7 +3969,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -3838,6 +4386,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.2.0",
@@ -4891,7 +5445,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -5598,6 +6151,18 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/intl-messageformat": {
+      "version": "10.7.18",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.18.tgz",
+      "integrity": "sha512-m3Ofv/X/tV8Y3tHXLohcuVuhWKo7BBq62cqY15etqmLxg2DZ34AGGgQDeR+SCta2+zICb1NX83af0GJmbQ1++g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.6",
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/icu-messageformat-parser": "2.11.4",
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/is-alphabetical": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
@@ -5803,7 +6368,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5849,7 +6413,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -5898,7 +6461,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -7677,7 +8239,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -7757,6 +8318,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/next": {
       "version": "16.1.1",
       "resolved": "https://registry.npmjs.org/next/-/next-16.1.1.tgz",
@@ -7808,6 +8378,92 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-intl": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/next-intl/-/next-intl-4.6.1.tgz",
+      "integrity": "sha512-KlWgWtKLBPUsTPgxqwyjws1wCMD2QKxLlVjeeGj53DC1JWfKmBShKOrhIP0NznZrRQ0GleeoDUeHSETmyyIFeA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/amannn"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/intl-localematcher": "^0.5.4",
+        "@parcel/watcher": "^2.4.1",
+        "@swc/core": "^1.15.2",
+        "negotiator": "^1.0.0",
+        "next-intl-swc-plugin-extractor": "^4.6.1",
+        "po-parser": "^2.0.0",
+        "use-intl": "^4.6.1"
+      },
+      "peerDependencies": {
+        "next": "^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0",
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/next-intl-swc-plugin-extractor": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/next-intl-swc-plugin-extractor/-/next-intl-swc-plugin-extractor-4.6.1.tgz",
+      "integrity": "sha512-+HHNeVERfSvuPDF7LYVn3pxst5Rf7EYdUTw7C7WIrYhcLaKiZ1b9oSRkTQddAN3mifDMCfHqO4kAQ/pcKiBl3A==",
+      "license": "MIT"
+    },
+    "node_modules/next-intl/node_modules/@swc/core": {
+      "version": "1.15.8",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.8.tgz",
+      "integrity": "sha512-T8keoJjXaSUoVBCIjgL6wAnhADIb09GOELzKg10CjNg+vLX48P93SME6jTfte9MZIm5m+Il57H3rTSk/0kzDUw==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3",
+        "@swc/types": "^0.1.25"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/swc"
+      },
+      "optionalDependencies": {
+        "@swc/core-darwin-arm64": "1.15.8",
+        "@swc/core-darwin-x64": "1.15.8",
+        "@swc/core-linux-arm-gnueabihf": "1.15.8",
+        "@swc/core-linux-arm64-gnu": "1.15.8",
+        "@swc/core-linux-arm64-musl": "1.15.8",
+        "@swc/core-linux-x64-gnu": "1.15.8",
+        "@swc/core-linux-x64-musl": "1.15.8",
+        "@swc/core-win32-arm64-msvc": "1.15.8",
+        "@swc/core-win32-ia32-msvc": "1.15.8",
+        "@swc/core-win32-x64-msvc": "1.15.8"
+      },
+      "peerDependencies": {
+        "@swc/helpers": ">=0.5.17"
+      },
+      "peerDependenciesMeta": {
+        "@swc/helpers": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/next-intl/node_modules/@swc/helpers": {
+      "version": "0.5.18",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
+      "integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/next-mdx-remote": {
@@ -7868,6 +8524,12 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT"
     },
     "node_modules/node-releases": {
       "version": "2.0.27",
@@ -8193,7 +8855,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -8201,6 +8862,12 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/po-parser": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/po-parser/-/po-parser-2.1.1.tgz",
+      "integrity": "sha512-ECF4zHLbUItpUgE3OTtLKlPjeBN+fKEczj2zYjDfCGOzicNs0GK3Vg2IoAYwx7LH/XYw43fZQP6xnZ4TkNxSLQ==",
+      "license": "MIT"
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
@@ -9499,7 +10166,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -9668,7 +10334,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -10000,6 +10666,20 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/use-intl": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/use-intl/-/use-intl-4.6.1.tgz",
+      "integrity": "sha512-mUIj6QvJZ7Rk33mLDxRziz1YiBBAnIji8YW4TXXMdYHtaPEbVucrXD3iKQGAqJhbVn0VnjrEtIKYO1B18mfSJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "^2.2.0",
+        "@schummar/icu-type-parser": "1.21.5",
+        "intl-messageformat": "^10.5.14"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0"
       }
     },
     "node_modules/use-sidecar": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "gray-matter": "^4.0.3",
     "lucide-react": "^0.562.0",
     "next": "16.1.1",
+    "next-intl": "^4.6.1",
     "next-mdx-remote": "^5.0.0",
     "next-themes": "^0.4.6",
     "react": "19.2.3",

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,0 +1,71 @@
+import createMiddleware from 'next-intl/middleware';
+import { NextRequest, NextResponse } from 'next/server';
+import { locales, defaultLocale } from './i18n';
+
+const intlMiddleware = createMiddleware({
+  locales,
+  defaultLocale,
+  localePrefix: 'as-needed', // No prefix for default locale (en)
+  localeDetection: true,
+});
+
+export default function proxy(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  // Skip middleware for API routes, static files, and special routes
+  if (
+    pathname.startsWith('/api') ||
+    pathname.startsWith('/_next') ||
+    pathname.startsWith('/og') ||
+    pathname.includes('.') ||
+    pathname === '/favicon.ico' ||
+    pathname === '/robots.txt' ||
+    pathname === '/sitemap.xml'
+  ) {
+    return NextResponse.next();
+  }
+
+  // Handle invalid locale prefixes - redirect to English equivalent
+  const firstSegment = pathname.split('/')[1];
+  if (firstSegment) {
+    const normalizedSegment = firstSegment.toLowerCase();
+    // Check if it looks like a locale but isn't valid
+    const validLocaleSegments = locales.map((l) => l.toLowerCase());
+    if (
+      normalizedSegment.length >= 2 &&
+      normalizedSegment.length <= 5 &&
+      normalizedSegment.match(/^[a-z]{2}(-[a-z]{2})?$/) &&
+      !validLocaleSegments.includes(normalizedSegment)
+    ) {
+      // Looks like a locale but invalid - redirect to English
+      const newPath = pathname.replace(`/${firstSegment}`, '') || '/';
+      return NextResponse.redirect(new URL(newPath, request.url));
+    }
+  }
+
+  // Run next-intl middleware
+  const response = intlMiddleware(request);
+
+  // Set locale cookie (1 year expiration)
+  // next-intl sets this header when locale is detected/changed
+  const locale = response.headers.get('x-middleware-request-x-next-intl-locale');
+  if (locale && response instanceof NextResponse) {
+    response.cookies.set('locale', locale, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      maxAge: 31536000, // 1 year
+      path: '/',
+    });
+  }
+
+  return response;
+}
+
+export const config = {
+  // Match all pathnames except for:
+  // - api routes
+  // - _next (Next.js internals)
+  // - Static files with extensions
+  matcher: ['/((?!api|_next|.*\\..*).*)', '/'],
+};


### PR DESCRIPTION
## Summary

- Add locale-based routing structure (`app/[locale]/`) for internationalized pages
- Implement i18n configuration with English (en) and Brazilian Portuguese (pt-BR) support
- Update components (header, footer, hero, article cards) with internationalization
- Add translation JSON files in `locales/` directory
- Extend posts library to handle multi-language content with locale suffixes

## Test plan

- [ ] Verify default locale (en) loads correctly at root path
- [ ] Verify pt-BR locale loads at `/pt-br/` path
- [ ] Test language switcher in header works correctly
- [ ] Confirm blog posts display in correct language based on locale
- [ ] Verify sitemap includes all locale variants
- [ ] Test RSS feed generation for each locale

🤖 Generated with [Claude Code](https://claude.com/claude-code)