### PR TITLE
feat: add pt-BR translations for example articles

### DIFF
--- a/content/posts/building-this-blog.pt-BR.mdx
+++ b/content/posts/building-this-blog.pt-BR.mdx
@@ -1,0 +1,215 @@
+---
+title: "Como Construí Este Blog com Next.js 15"
+date: "2025-12-29"
+description: "Um passo a passo técnico de como construir um blog moderno com Next.js 15, MDX e Tailwind CSS. Aprenda sobre a arquitetura, decisões de design e principais recursos."
+tags: ["nextjs", "tutorial", "desenvolvimento-web", "react", "tailwindcss"]
+coverImage: ""
+draft: false
+featured: true
+lang: "pt-BR"
+---
+
+# Como Construí Este Blog com Next.js 15
+
+Construir um blog pessoal é um rito de passagem para desenvolvedores. É uma chance de praticar suas habilidades, experimentar novas tecnologias e criar algo exclusivamente seu. Neste post, vou guiá-lo através de como construí este blog usando tecnologias web modernas.
+
+<Callout type="info">
+Este é um guia abrangente cobrindo arquitetura, decisões de design e detalhes de implementação. Use o **Índice** à direita para navegar para seções específicas.
+</Callout>
+
+## A Stack Tecnológica
+
+Antes de mergulhar na implementação, vamos olhar as tecnologias que alimentam este blog:
+
+| Tecnologia | Propósito |
+|------------|---------|
+| Next.js 15 | Framework React com App Router |
+| MDX | Markdown com componentes JSX |
+| Tailwind CSS v4 | Estilização utility-first |
+| TypeScript | Desenvolvimento type-safe |
+| Shiki | Syntax highlighting |
+| Fuse.js | Busca client-side |
+
+## Estrutura do Projeto
+
+O blog segue uma estrutura bem organizada que separa responsabilidades claramente:
+
+```bash
+├── app/                    # Páginas do Next.js App Router
+│   ├── blog/
+│   │   ├── [slug]/        # Páginas dinâmicas de posts
+│   │   └── page.tsx       # Listagem do blog
+│   ├── tag/[tag]/         # Views filtradas por tag
+│   ├── api/               # Rotas de API
+│   └── layout.tsx         # Layout raiz
+├── components/            # Componentes React
+│   ├── blog/              # Componentes específicos do blog
+│   ├── mdx/               # Componentes customizados MDX
+│   ├── search/            # Funcionalidade de busca
+│   └── ui/                # Componentes UI reutilizáveis
+├── content/posts/         # Posts do blog em MDX
+├── lib/                   # Funções utilitárias
+└── public/                # Assets estáticos
+```
+
+## Gerenciamento de Conteúdo com MDX
+
+Uma das decisões-chave foi usar MDX para conteúdo. MDX permite escrever Markdown enquanto incorpora componentes React diretamente no conteúdo.
+
+<Callout type="tip">
+MDX combina a simplicidade do Markdown com o poder dos componentes React. Perfeito para blogs técnicos!
+</Callout>
+
+### Schema do Frontmatter
+
+Cada post inclui metadados no frontmatter:
+
+```yaml
+---
+title: "Título do Post"
+date: "2025-12-30"
+description: "Uma breve descrição para SEO"
+tags: ["tag1", "tag2"]
+coverImage: "/images/cover.jpg"  # Opcional
+draft: false                      # Oculto se true
+featured: true                    # Aparece na homepage
+---
+```
+
+### Componentes Customizados
+
+Criei vários componentes MDX customizados para melhorar a experiência de leitura:
+
+```tsx
+// Componente Callout para notas importantes
+<Callout type="info">
+  Este é um callout informativo!
+</Callout>
+
+// Embed do YouTube
+<YouTubeEmbed videoId="dQw4w9WgXcQ" />
+
+// Blocos de código com syntax highlighting
+// Alimentado pelo Shiki com o tema GitHub Dark
+```
+
+## Implementando a Busca
+
+A funcionalidade de busca usa Fuse.js para busca fuzzy rápida no client-side:
+
+```typescript
+import Fuse from 'fuse.js';
+
+const fuse = new Fuse(posts, {
+  keys: [
+    { name: 'title', weight: 2 },
+    { name: 'description', weight: 1.5 },
+    { name: 'tags', weight: 1.5 },
+    { name: 'content', weight: 1 },
+  ],
+  threshold: 0.3,
+  includeMatches: true,
+});
+```
+
+O diálogo de busca é acionado com `Ctrl+K` (ou `Cmd+K` no Mac), proporcionando uma experiência familiar para desenvolvedores.
+
+## Geração Estática e SEO
+
+A geração estática do Next.js 15 garante excelente performance e SEO:
+
+```typescript
+// Gerar paths estáticos no build time
+export async function generateStaticParams() {
+  const posts = getAllPosts();
+  return posts.map((post) => ({ slug: post.slug }));
+}
+
+// Gerar metadata para cada post
+export async function generateMetadata({ params }) {
+  const post = getPostBySlug(params.slug);
+  return {
+    title: post.frontmatter.title,
+    description: post.frontmatter.description,
+    openGraph: {
+      type: 'article',
+      // ... mais metadata
+    },
+  };
+}
+```
+
+### Recursos de SEO
+
+O blog inclui otimização abrangente de SEO:
+
+- **Sitemap Dinâmico** — Inclui automaticamente todos os posts e tags
+- **Feed RSS** — Assine em `/feed.xml`
+- **Imagens OG Dinâmicas** — Geradas para cada post
+- **JSON-LD** — Dados estruturados para resultados de busca ricos
+
+<Callout type="warning">
+Lembre-se de atualizar `lib/config.ts` com a URL real do seu site antes de fazer deploy!
+</Callout>
+
+## Estilização com Tailwind CSS v4
+
+Tailwind CSS v4 traz melhorias significativas:
+
+```css
+/* Cores do tema Electric Violet */
+:root {
+  --primary: #8b5cf6;
+  --background: #0a0a0f;
+  --foreground: #f1f5f9;
+}
+
+/* Estilização do conteúdo do artigo */
+.article-content {
+  font-size: 1.125rem;
+  line-height: 1.75;
+}
+```
+
+O design segue um tema "Electric Violet" com fundo escuro e acentos roxos, criando uma estética moderna e amigável para desenvolvedores.
+
+## Otimizações de Performance
+
+Várias otimizações garantem tempos de carregamento rápidos:
+
+1. **Geração Estática** — Páginas pré-renderizadas no build time
+2. **Otimização de Imagens** — Otimização automática de imagens do Next.js
+3. **Code Splitting** — Code splitting automático por rota
+4. **Otimização de Fontes** — Usando `next/font` para carregamento otimizado
+
+## Deploy
+
+O blog foi projetado para deploy fácil na Vercel:
+
+```bash
+# Push para o GitHub
+git add .
+git commit -m "Deploy blog"
+git push origin main
+
+# Vercel faz auto-deploy do branch main
+```
+
+## O Que Vem Depois?
+
+Melhorias futuras que estou planejando:
+
+- [ ] Adicionar contadores de visualização com edge functions
+- [ ] Implementar assinatura de newsletter
+- [ ] Adicionar sugestões de posts relacionados
+- [ ] Criar uma seção de portfólio
+
+<Callout type="info">
+Quer construir o seu próprio? Confira o código fonte no GitHub para a implementação completa!
+</Callout>
+
+## Conclusão
+
+Construir este blog foi uma ótima experiência de aprendizado. Next.js 15 com o App Router fornece uma excelente base para sites focados em conteúdo, e MDX torna a escrita de conteúdo técnico agradável.
+
+Sinta-se à vontade para explorar o código e adaptá-lo para seus próprios projetos. Bom código!

--- a/content/posts/code-examples.pt-BR.mdx
+++ b/content/posts/code-examples.pt-BR.mdx
@@ -1,0 +1,345 @@
+---
+title: "Snippets de Código e Exemplos"
+date: "2025-12-28"
+description: "Uma coleção de snippets de código úteis demonstrando syntax highlighting em múltiplas linguagens incluindo TypeScript, React, CSS e mais."
+tags: ["codigo", "snippets", "referencia", "typescript", "react"]
+coverImage: ""
+draft: false
+featured: false
+lang: "pt-BR"
+---
+
+# Snippets de Código e Exemplos
+
+Este post demonstra as capacidades de syntax highlighting deste blog. Todos os blocos de código são alimentados pelo **Shiki** com o tema GitHub Dark para highlighting bonito e preciso.
+
+## Exemplos TypeScript
+
+### Tipos Utilitários Genéricos
+
+```typescript
+// Um tipo utilitário que torna todas as propriedades opcionais e anuláveis
+type DeepPartial<T> = {
+  [P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : T[P] | null;
+};
+
+// Exemplo de uso
+interface User {
+  id: number;
+  profile: {
+    name: string;
+    email: string;
+    settings: {
+      theme: 'light' | 'dark';
+      notifications: boolean;
+    };
+  };
+}
+
+const partialUser: DeepPartial<User> = {
+  profile: {
+    name: 'John',
+    settings: {
+      theme: 'dark',
+    },
+  },
+};
+```
+
+### Tratamento de Erros Assíncronos
+
+```typescript
+// Um wrapper para funções assíncronas que retorna uma tupla
+type Result<T, E = Error> = [T, null] | [null, E];
+
+async function tryCatch<T>(
+  promise: Promise<T>
+): Promise<Result<T>> {
+  try {
+    const data = await promise;
+    return [data, null];
+  } catch (error) {
+    return [null, error as Error];
+  }
+}
+
+// Uso
+async function fetchUser(id: string) {
+  const [user, error] = await tryCatch(
+    fetch(`/api/users/${id}`).then(res => res.json())
+  );
+
+  if (error) {
+    console.error('Falha ao buscar usuário:', error.message);
+    return null;
+  }
+
+  return user;
+}
+```
+
+## Componentes React
+
+### Hook Customizado com Cleanup
+
+```tsx
+import { useState, useEffect, useCallback } from 'react';
+
+interface UseFetchOptions<T> {
+  initialData?: T;
+  enabled?: boolean;
+}
+
+function useFetch<T>(url: string, options: UseFetchOptions<T> = {}) {
+  const { initialData, enabled = true } = options;
+
+  const [data, setData] = useState<T | undefined>(initialData);
+  const [error, setError] = useState<Error | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const fetchData = useCallback(async () => {
+    if (!enabled) return;
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const response = await fetch(url);
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+      const json = await response.json();
+      setData(json);
+    } catch (e) {
+      setError(e instanceof Error ? e : new Error('Unknown error'));
+    } finally {
+      setIsLoading(false);
+    }
+  }, [url, enabled]);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    fetchData();
+    return () => controller.abort();
+  }, [fetchData]);
+
+  return { data, error, isLoading, refetch: fetchData };
+}
+
+export default useFetch;
+```
+
+### Componente com Animações
+
+```tsx
+'use client';
+
+import { motion, AnimatePresence } from 'framer-motion';
+import { useState } from 'react';
+
+interface ToastProps {
+  message: string;
+  type: 'success' | 'error' | 'info';
+}
+
+export function Toast({ message, type }: ToastProps) {
+  const [isVisible, setIsVisible] = useState(true);
+
+  const colors = {
+    success: 'bg-green-500',
+    error: 'bg-red-500',
+    info: 'bg-blue-500',
+  };
+
+  return (
+    <AnimatePresence>
+      {isVisible && (
+        <motion.div
+          initial={{ opacity: 0, y: 50, scale: 0.3 }}
+          animate={{ opacity: 1, y: 0, scale: 1 }}
+          exit={{ opacity: 0, scale: 0.5, transition: { duration: 0.2 } }}
+          className={`${colors[type]} px-4 py-2 rounded-lg shadow-lg`}
+        >
+          <p className="text-white font-medium">{message}</p>
+          <button
+            onClick={() => setIsVisible(false)}
+            className="absolute top-1 right-2 text-white/80 hover:text-white"
+          >
+            ×
+          </button>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}
+```
+
+## CSS e Tailwind
+
+### Plugin Customizado do Tailwind
+
+```javascript
+// tailwind.config.js
+const plugin = require('tailwindcss/plugin');
+
+module.exports = {
+  plugins: [
+    plugin(function({ addUtilities, theme }) {
+      const newUtilities = {
+        '.text-gradient': {
+          'background': 'linear-gradient(135deg, #8b5cf6 0%, #ec4899 100%)',
+          '-webkit-background-clip': 'text',
+          '-webkit-text-fill-color': 'transparent',
+        },
+        '.glass': {
+          'background': 'rgba(255, 255, 255, 0.1)',
+          'backdrop-filter': 'blur(10px)',
+          'border': '1px solid rgba(255, 255, 255, 0.2)',
+        },
+      };
+      addUtilities(newUtilities);
+    }),
+  ],
+};
+```
+
+### Layout CSS Grid
+
+```css
+/* Grid responsivo moderno com áreas nomeadas */
+.dashboard-layout {
+  display: grid;
+  grid-template-columns: 250px 1fr 300px;
+  grid-template-rows: 60px 1fr 50px;
+  grid-template-areas:
+    "header header header"
+    "sidebar main aside"
+    "footer footer footer";
+  min-height: 100vh;
+  gap: 1rem;
+}
+
+.dashboard-layout > header { grid-area: header; }
+.dashboard-layout > aside:first-of-type { grid-area: sidebar; }
+.dashboard-layout > main { grid-area: main; }
+.dashboard-layout > aside:last-of-type { grid-area: aside; }
+.dashboard-layout > footer { grid-area: footer; }
+
+/* Responsivo: Empilhar no mobile */
+@media (max-width: 768px) {
+  .dashboard-layout {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto;
+    grid-template-areas:
+      "header"
+      "main"
+      "sidebar"
+      "aside"
+      "footer";
+  }
+}
+```
+
+## Comandos de Terminal
+
+### Operações Comuns do Git
+
+```bash
+# Rebase interativo para os últimos 5 commits
+git rebase -i HEAD~5
+
+# Stash com uma mensagem e incluir arquivos não rastreados
+git stash push -u -m "Work in progress: feature X"
+
+# Cherry-pick de um intervalo de commits
+git cherry-pick start_commit^..end_commit
+
+# Encontrar qual commit introduziu um bug
+git bisect start
+git bisect bad HEAD
+git bisect good v1.0.0
+# Git vai guiá-lo pelo resto
+
+# Limpar branches já mergeados
+git branch --merged | grep -v "\*\|main\|master" | xargs -n 1 git branch -d
+```
+
+### Comandos Docker
+
+```bash
+# Build e executar com live reload para desenvolvimento
+docker compose -f docker-compose.dev.yml up --build
+
+# Executar um comando em um container em execução
+docker exec -it container_name /bin/sh
+
+# Limpar todos os recursos não utilizados
+docker system prune -a --volumes
+
+# Ver logs com timestamps e seguir
+docker logs -f --timestamps container_name
+
+# Copiar arquivos do container para o host
+docker cp container_name:/path/in/container ./local/path
+```
+
+## Configuração JSON
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["DOM", "DOM.Iterable", "ES2022"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}
+```
+
+## Queries SQL
+
+```sql
+-- Encontrar usuários com suas estatísticas de pedidos
+SELECT
+  u.id,
+  u.name,
+  u.email,
+  COUNT(o.id) as total_orders,
+  COALESCE(SUM(o.total), 0) as total_spent,
+  MAX(o.created_at) as last_order_date
+FROM users u
+LEFT JOIN orders o ON u.id = o.user_id
+WHERE u.created_at >= DATE_SUB(NOW(), INTERVAL 1 YEAR)
+GROUP BY u.id, u.name, u.email
+HAVING total_orders > 0
+ORDER BY total_spent DESC
+LIMIT 100;
+
+-- Criar um índice para melhor performance de query
+CREATE INDEX idx_orders_user_created
+ON orders (user_id, created_at DESC);
+```
+
+<Callout type="info">
+Todos os snippets de código estão prontos para copiar! Clique no botão de copiar que aparece quando você passa o mouse sobre qualquer bloco de código.
+</Callout>
+
+## Conclusão
+
+Estes exemplos demonstram a variedade de syntax highlighting disponível neste blog. O highlighter Shiki fornece highlighting preciso e consistente com o tema para todas as principais linguagens de programação.
+
+Sinta-se à vontade para usar estes snippets em seus próprios projetos!

--- a/content/posts/welcome.pt-BR.mdx
+++ b/content/posts/welcome.pt-BR.mdx
@@ -1,0 +1,90 @@
+---
+title: "Bem-vindo ao DevGiroux"
+date: "2025-12-30"
+description: "Bem-vindo ao meu blog pessoal onde compartilho pensamentos sobre desenvolvimento web, programação e tecnologia. Vamos construir coisas incríveis juntos!"
+tags: ["bem-vindo", "pessoal", "introducao"]
+coverImage: ""
+draft: false
+featured: true
+lang: "pt-BR"
+---
+
+# Bem-vindo ao DevGiroux!
+
+Olá e seja bem-vindo! Estou animado para compartilhar este espaço com você, onde vamos explorar o fascinante mundo do desenvolvimento web, programação e tecnologia.
+
+<Callout type="info">
+Este blog foi construído com **Next.js 15**, **MDX** e **Tailwind CSS**. Você pode encontrar o código fonte no GitHub!
+</Callout>
+
+## O Que Você Vai Encontrar Aqui
+
+Este blog é dedicado a compartilhar conhecimento, insights e experiências em:
+
+- **Desenvolvimento Web**: Frameworks modernos, melhores práticas e técnicas de ponta
+- **Programação**: Tutoriais de código, abordagens de resolução de problemas e padrões de design
+- **Tecnologia**: Últimas tendências, ferramentas e inovações no mundo tech
+
+## Minha Abordagem
+
+Acredito em aprender fazendo e compartilhar conhecimento com a comunidade. Cada artigo tem como objetivo ser:
+
+1. **Prático** — Exemplos reais e casos de uso que você pode aplicar imediatamente
+2. **Aprofundado** — Explicações completas sem pular detalhes importantes
+3. **Acessível** — Escrita clara tanto para iniciantes quanto para desenvolvedores experientes
+
+<Callout type="tip">
+Use o **recurso de busca** (pressione `Ctrl+K` ou `Cmd+K`) para encontrar rapidamente artigos sobre tópicos específicos!
+</Callout>
+
+## Um Exemplo Rápido de Código
+
+Aqui está um hook React simples que uso em muitos dos meus projetos:
+
+```typescript
+import { useState, useEffect } from 'react';
+
+function useLocalStorage<T>(key: string, initialValue: T) {
+  const [storedValue, setStoredValue] = useState<T>(() => {
+    if (typeof window === 'undefined') {
+      return initialValue;
+    }
+    try {
+      const item = window.localStorage.getItem(key);
+      return item ? JSON.parse(item) : initialValue;
+    } catch (error) {
+      console.error(error);
+      return initialValue;
+    }
+  });
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(key, JSON.stringify(storedValue));
+    }
+  }, [key, storedValue]);
+
+  return [storedValue, setStoredValue] as const;
+}
+```
+
+## O Que Vem Por Aí?
+
+Estou trabalhando em vários tópicos empolgantes, incluindo:
+
+- Desenvolvimento web moderno com **Next.js 15** e o App Router
+- Melhores práticas e padrões avançados de **TypeScript**
+- Construindo aplicações escaláveis com arquitetura adequada
+- Técnicas de otimização de performance para apps React
+
+<Callout type="warning">
+Este blog está em desenvolvimento ativo! Espere novos recursos e conteúdos regularmente.
+</Callout>
+
+## Mantenha-se Conectado
+
+Sinta-se à vontade para explorar os artigos, deixar comentários e entrar em contato se tiver perguntas ou sugestões para tópicos futuros!
+
+> "A melhor maneira de aprender é construir algo e compartilhar com os outros."
+
+Boa leitura e bom código!


### PR DESCRIPTION
## Summary

- Add Brazilian Portuguese translations for all 3 example blog articles
- `welcome.pt-BR.mdx`: Blog introduction translated to Portuguese
- `building-this-blog.pt-BR.mdx`: Technical walkthrough translated to Portuguese
- `code-examples.pt-BR.mdx`: Code snippets showcase translated to Portuguese

All translations use formal tone (você) and preserve code blocks unchanged.

## Test plan

- [ ] Verify pt-BR articles load correctly at `/pt-br/blog/[slug]`
- [ ] Check that translations display proper Portuguese characters
- [ ] Confirm MDX components render correctly in translated articles

🤖 Generated with [Claude Code](https://claude.com/claude-code)