### PR TITLE
fix(i18n): use next-intl locale-aware navigation for proper locale switching

### DIFF
--- a/components/blog/article-card.tsx
+++ b/components/blog/article-card.tsx
@@ -1,12 +1,12 @@
 'use client';
 
-import Link from 'next/link';
 import Image from 'next/image';
 import { Calendar, Clock } from 'lucide-react';
 import { useLocale, useTranslations } from 'next-intl';
 import { Card } from '@/components/ui/card';
 import { TagBadge } from './tag-badge';
-import { getLocalizedPath, formatShortDate, Locale } from '@/lib/i18n';
+import { formatShortDate, Locale } from '@/lib/i18n';
+import { Link } from '@/lib/navigation';
 import { cn } from '@/lib/utils';
 
 interface ArticleCardProps {
@@ -35,11 +35,10 @@ export function ArticleCard({
   const locale = useLocale() as Locale;
   const t = useTranslations('languageBadge');
 
-  const href = getLocalizedPath(`/blog/${slug}`, locale);
   const formattedDate = formatShortDate(date, locale);
 
   return (
-    <Link href={href}>
+    <Link href={`/blog/${slug}`}>
       <Card className="group overflow-hidden border-border bg-card backdrop-blur transition-all hover:border-primary/50 hover:bg-surface-hover hover:shadow-lg hover:shadow-primary/10">
         {image && (
           <div className="relative aspect-video w-full overflow-hidden">

--- a/components/blog/tag-badge.tsx
+++ b/components/blog/tag-badge.tsx
@@ -1,4 +1,4 @@
-import Link from 'next/link';
+import { Link } from '@/lib/navigation';
 import { Badge } from '@/components/ui/badge';
 
 interface TagBadgeProps {

--- a/components/home/hero.tsx
+++ b/components/home/hero.tsx
@@ -1,13 +1,11 @@
 'use client';
 
-import Link from 'next/link';
-import { useLocale, useTranslations } from 'next-intl';
+import { useTranslations } from 'next-intl';
 import { ArrowRight, Sparkles } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { getLocalizedPath, Locale } from '@/lib/i18n';
+import { Link } from '@/lib/navigation';
 
 export function Hero() {
-  const locale = useLocale() as Locale;
   const t = useTranslations('hero');
 
   return (
@@ -45,7 +43,7 @@ export function Hero() {
               size="lg"
               className="bg-primary text-primary-foreground hover:bg-primary/90 shadow-lg shadow-primary/20"
             >
-              <Link href={getLocalizedPath('/blog', locale)}>
+              <Link href="/blog">
                 {t('exploreArticles')}
                 <ArrowRight className="ml-2 h-4 w-4" />
               </Link>

--- a/components/layout/footer.tsx
+++ b/components/layout/footer.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import Link from "next/link"
 import { useLocale, useTranslations } from 'next-intl'
 import { Github, Twitter, Instagram, Youtube, Rss } from "lucide-react"
 import { siteConfig } from "@/lib/config"
-import { getLocalizedPath, Locale } from "@/lib/i18n"
+import { Link } from "@/lib/navigation"
+import { Locale } from "@/lib/i18n"
 
 const socialLinks = [
   { href: siteConfig.links.twitter, icon: Twitter, label: "Twitter" },
@@ -27,7 +27,7 @@ export function Footer() {
         <div className="flex flex-col items-center justify-between gap-6 md:flex-row">
           <div className="flex flex-col items-center gap-2 md:items-start">
             <Link
-              href={getLocalizedPath('/', locale)}
+              href="/"
               className="text-lg font-semibold transition-colors hover:text-primary"
             >
               <span className="bg-gradient-to-r from-primary to-cyan-400 bg-clip-text text-transparent">

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -1,10 +1,8 @@
 "use client"
 
 import * as React from "react"
-import Link from "next/link"
-import { usePathname, useRouter } from "next/navigation"
-import { useLocale, useTranslations } from 'next-intl'
 import { Menu, X, Search, Globe } from "lucide-react"
+import { useLocale, useTranslations } from 'next-intl'
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import {
@@ -16,7 +14,8 @@ import {
 import { ThemeToggle } from "./theme-toggle"
 import { siteConfig } from "@/lib/config"
 import { useSearch } from "@/components/search"
-import { getLocalizedPath, stripLocaleFromPath, Locale } from "@/lib/i18n"
+import { Link, usePathname, useRouter } from "@/lib/navigation"
+import { Locale } from "@/lib/i18n"
 
 export function Header() {
   const pathname = usePathname()
@@ -36,25 +35,19 @@ export function Header() {
 
   // Switch language while staying on same page
   const switchLocale = (newLocale: Locale) => {
-    const { path } = stripLocaleFromPath(pathname)
-    const newPath = getLocalizedPath(path, newLocale)
-    router.push(newPath)
+    router.replace(pathname, { locale: newLocale })
   }
-
-  // Get localized href
-  const getHref = (path: string) => getLocalizedPath(path, locale)
 
   // Check if path is active
   const isActive = (path: string) => {
-    const { path: currentPath } = stripLocaleFromPath(pathname)
-    return currentPath === path
+    return pathname === path
   }
 
   return (
     <header className="sticky top-0 z-50 w-full border-b border-border bg-background/80 backdrop-blur-md">
       <div className="container mx-auto flex h-16 max-w-4xl items-center justify-between px-4">
         <Link
-          href={getHref("/")}
+          href="/"
           className="flex items-center space-x-2 text-xl font-semibold transition-colors hover:text-primary"
         >
           <span className="bg-gradient-to-r from-primary to-cyan-400 bg-clip-text text-transparent">
@@ -67,7 +60,7 @@ export function Header() {
           {navItems.map((item) => (
             <Link
               key={item.href}
-              href={getHref(item.href)}
+              href={item.href}
               className={cn(
                 "px-4 py-2 text-sm font-light transition-colors hover:text-primary",
                 isActive(item.href)
@@ -181,7 +174,7 @@ export function Header() {
             {navItems.map((item) => (
               <Link
                 key={item.href}
-                href={getHref(item.href)}
+                href={item.href}
                 className={cn(
                   "rounded-md px-4 py-2 text-sm font-light transition-colors hover:bg-surface-hover",
                   isActive(item.href)

--- a/lib/navigation.ts
+++ b/lib/navigation.ts
@@ -1,0 +1,9 @@
+import { createNavigation } from 'next-intl/navigation';
+import { locales, defaultLocale } from './i18n';
+
+export const { Link, redirect, usePathname, useRouter, getPathname } =
+  createNavigation({
+    locales,
+    defaultLocale,
+    localePrefix: 'as-needed',
+  });


### PR DESCRIPTION
Fixed the issue where clicking the English language selector didn't properly
switch the locale. The problem was that the application was using Next.js
navigation APIs directly instead of next-intl's locale-aware versions.

Changes:
- Created lib/navigation.ts with locale-aware routing utilities using
  createNavigation from next-intl
- Updated Header component to use router.replace(pathname, {locale}) for
  proper locale switching
- Migrated all components from next/link and next/navigation to locale-aware
  versions from lib/navigation
- Removed manual locale path construction with getLocalizedPath and
  stripLocaleFromPath in favor of next-intl's automatic handling

This ensures that locale switching works bidirectionally (English ↔ Portuguese)
and that all navigation respects the current locale context.