### PR TITLE
fix: prevent topic tags overflow on narrow viewports

### DIFF
--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -139,11 +139,14 @@ export default async function HomePage({ params }: HomePageProps) {
             </p>
             <div className="mb-12 h-px bg-border animate-draw-line" />
 
-            <p className="max-w-3xl text-lg leading-loose">
+            <p className="max-w-3xl text-lg leading-loose break-words">
               {tags.map(({ tag, count }, i) => (
                 <span key={tag}>
                   {i > 0 && (
-                    <span className="mx-2 text-muted-foreground/30 select-none">/</span>
+                    <>
+                      {' '}
+                      <span className="text-muted-foreground/30 select-none">/</span>{' '}
+                    </>
                   )}
                   <Link
                     href={`/tag/${encodeURIComponent(tag)}`}


### PR DESCRIPTION
## Summary
- The "Explore by Topic" tag list on the homepage was overflowing horizontally on mobile (last tag rendering as `perso…` past the viewport edge).
- Root cause: the `/` separator used `mx-2` margin instead of real whitespace, so the browser saw `/tag` as a single unbreakable inline unit with no line-wrap opportunity.
- Replaced the margin with literal whitespace characters around the `/`, and added `break-words` on the paragraph as defense against any single long tag name.

## Test plan
- [ ] Verify the "Explore by Topic" section wraps cleanly on mobile widths (≤ 390px)
- [ ] Verify desktop appearance is unchanged
- [ ] Verify tag links and hover styling still work
- [ ] Check both EN and PT-BR locale homepages

https://claude.ai/code/session_01Xp9TcJKzjM9fxKvftN3YuS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xp9TcJKzjM9fxKvftN3YuS)_