### PR TITLE
Add /projects page

### DIFF
--- a/app/[locale]/projects/page.tsx
+++ b/app/[locale]/projects/page.tsx
@@ -1,0 +1,29 @@
+import { getTranslations, setRequestLocale } from 'next-intl/server';
+import { ProjectsHero } from '@/components/projects/projects-hero';
+import { ProjectsGrid } from '@/components/projects/projects-grid';
+
+interface ProjectsPageProps {
+  params: Promise<{ locale: string }>;
+}
+
+export async function generateMetadata({ params }: ProjectsPageProps) {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: 'projects' });
+
+  return {
+    title: t('pageTitle'),
+    description: t('pageDescription'),
+  };
+}
+
+export default async function ProjectsPage({ params }: ProjectsPageProps) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+
+  return (
+    <>
+      <ProjectsHero />
+      <ProjectsGrid />
+    </>
+  );
+}

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -40,6 +40,7 @@ export function Header() {
     { href: "/", label: t("home") },
     { href: "/about", label: t("about") },
     { href: "/blog", label: t("blog") },
+    { href: "/projects", label: t("projects") },
   ]
 
   const switchLocale = (newLocale: Locale) => {

--- a/components/projects/project-card.tsx
+++ b/components/projects/project-card.tsx
@@ -1,0 +1,84 @@
+import { Link } from '@/lib/navigation';
+
+export interface Project {
+  name: string;
+  description: string;
+  status: string;
+  tags: string[];
+  githubUrl: string;
+  liveUrl?: string;
+  blogPostPath?: string;
+}
+
+interface ProjectCardProps {
+  project: Project;
+  labels: {
+    code: string;
+    visit: string;
+    readPost: string;
+  };
+}
+
+export function ProjectCard({ project, labels }: ProjectCardProps) {
+  return (
+    <article className="flex flex-col gap-4 border-b border-border/50 py-10 last:border-b-0">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-baseline sm:justify-between">
+        <h3 className="font-display text-3xl font-bold text-foreground">
+          {project.name}
+        </h3>
+        <span className="font-mono text-xs uppercase tracking-wide text-primary">
+          {project.status}
+        </span>
+      </div>
+
+      <p className="max-w-3xl leading-relaxed text-muted-foreground">
+        {project.description}
+      </p>
+
+      <ul className="flex flex-wrap gap-x-3 gap-y-1">
+        {project.tags.map((tag) => (
+          <li
+            key={tag}
+            className="font-mono text-xs uppercase tracking-wide text-muted-foreground"
+          >
+            {tag}
+          </li>
+        ))}
+      </ul>
+
+      <div className="flex flex-wrap gap-x-6 gap-y-2 pt-1">
+        <a
+          href={project.githubUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="group inline-flex items-center gap-2 text-sm font-medium uppercase tracking-wide text-primary transition-colors hover:text-primary/80"
+        >
+          {labels.code}
+          <span className="inline-block transition-transform group-hover:translate-x-1">&rarr;</span>
+        </a>
+
+        {project.liveUrl && (
+          <a
+            href={project.liveUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="group inline-flex items-center gap-2 text-sm font-medium uppercase tracking-wide text-primary transition-colors hover:text-primary/80"
+          >
+            {labels.visit}
+            <span className="inline-block transition-transform group-hover:translate-x-1">&rarr;</span>
+          </a>
+        )}
+
+        {project.blogPostPath && (
+          <Link
+            href={project.blogPostPath}
+            className="group inline-flex items-center gap-2 text-sm font-medium uppercase tracking-wide text-muted-foreground transition-colors hover:text-primary"
+          >
+            {labels.readPost}
+            <span className="inline-block transition-transform group-hover:translate-x-1">&rarr;</span>
+          </Link>
+        )}
+      </div>
+    </article>
+  );
+}

--- a/components/projects/projects-grid.tsx
+++ b/components/projects/projects-grid.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { ProjectCard, type Project } from './project-card';
+
+export function ProjectsGrid() {
+  const t = useTranslations('projects');
+
+  const projects: Project[] = [
+    {
+      name: 'SafeNudge',
+      description: t('items.safenudge.description'),
+      status: t('items.safenudge.status'),
+      tags: ['Rust', 'Anchor', 'Solana', 'TypeScript', 'React'],
+      githubUrl: 'https://github.com/davigiroux/safenudge.xyz',
+      liveUrl: 'https://safenudge.xyz',
+      blogPostPath: '/blog/building-safenudge-my-first-onchain-app',
+    },
+    {
+      name: 'BaseVault',
+      description: t('items.basevault.description'),
+      status: t('items.basevault.status'),
+      tags: ['Solidity', 'Foundry', 'EVM', 'React', 'TypeScript', 'wagmi'],
+      githubUrl: 'https://github.com/davigiroux/BaseVault',
+    },
+    {
+      name: 'FlagKit',
+      description: t('items.flagkit.description'),
+      status: t('items.flagkit.status'),
+      tags: ['Go', 'React', 'TypeScript', 'PostgreSQL', 'Redis'],
+      githubUrl: 'https://github.com/davigiroux/flagkit',
+    },
+    {
+      name: 'SolEscrow',
+      description: t('items.solescrow.description'),
+      status: t('items.solescrow.status'),
+      tags: ['Rust', 'Anchor', 'Solana', 'TypeScript'],
+      githubUrl: 'https://github.com/davigiroux/sol-escrow',
+    },
+  ];
+
+  const labels = {
+    code: t('links.code'),
+    visit: t('links.visit'),
+    readPost: t('links.readPost'),
+  };
+
+  return (
+    <section className="bg-surface py-16 sm:py-24">
+      <div className="container mx-auto max-w-5xl px-4">
+        <p className="mb-3 text-xs font-medium uppercase tracking-[0.2em] text-muted-foreground">
+          {t('list.label')}
+        </p>
+        <div className="mb-8 h-px bg-border animate-draw-line" />
+
+        <div className="max-w-4xl">
+          {projects.map((project) => (
+            <ProjectCard key={project.name} project={project} labels={labels} />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/projects/projects-hero.tsx
+++ b/components/projects/projects-hero.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+
+export function ProjectsHero() {
+  const t = useTranslations('projects.hero');
+
+  return (
+    <section className="py-32">
+      <div className="container mx-auto max-w-5xl px-4">
+        <div className="max-w-3xl">
+          <p className="mb-6 text-xs font-medium uppercase tracking-[0.2em] text-muted-foreground animate-reveal-up">
+            {t('label')}
+          </p>
+
+          <h1 className="mb-4 font-display text-5xl font-bold leading-[1.05] text-foreground animate-text-reveal lg:text-7xl">
+            {t('title')}
+          </h1>
+
+          <p className="mb-8 text-lg font-medium text-primary animate-reveal-up" style={{ animationDelay: '150ms' }}>
+            {t('tagline')}
+          </p>
+
+          <p className="max-w-2xl text-lg font-light leading-relaxed text-muted-foreground animate-reveal-up" style={{ animationDelay: '300ms' }}>
+            {t('description')}
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/locales/en.json
+++ b/locales/en.json
@@ -2,7 +2,8 @@
   "nav": {
     "home": "Home",
     "about": "About",
-    "blog": "Blog"
+    "blog": "Blog",
+    "projects": "Projects"
   },
   "hero": {
     "title1": "Building, Learning,",
@@ -74,6 +75,42 @@
     "linkedin": "Share on LinkedIn",
     "copyLink": "Copy link",
     "copied": "Copied!"
+  },
+  "projects": {
+    "pageTitle": "Projects",
+    "pageDescription": "Projects I'm building in public across EVM and Solana — onchain apps, DeFi tooling, and developer infrastructure.",
+    "hero": {
+      "label": "PROJECTS",
+      "title": "Projects",
+      "tagline": "Building in public across EVM and Solana",
+      "description": "A running list of things I'm shipping — onchain apps, DeFi experiments, and developer tools. Some are live, some are deployed to testnets, all are open source."
+    },
+    "list": {
+      "label": "WHAT I'M BUILDING"
+    },
+    "links": {
+      "code": "Code",
+      "visit": "Visit",
+      "readPost": "Read the post"
+    },
+    "items": {
+      "safenudge": {
+        "description": "Group savings protocol on Solana. Friends commit to saving together; the blockchain enforces deposits, schedule, and penalties. Inspired by Brazilian MOAIs.",
+        "status": "Live on devnet"
+      },
+      "basevault": {
+        "description": "DeFi yield vault on Base. Deposits earn yield via Aave v3. Built with Solidity/Foundry, 100% test coverage, wagmi v2/viem v2 frontend.",
+        "status": "Deployed on Base Sepolia"
+      },
+      "flagkit": {
+        "description": "Self-hostable feature flag service. Go API with Redis caching, React/TypeScript dashboard, TypeScript SDK published to npm.",
+        "status": "npm"
+      },
+      "solescrow": {
+        "description": "Anchor escrow program on Solana devnet. Learning project covering PDAs, CPIs, and SPL token transfers.",
+        "status": "Live on devnet"
+      }
+    }
   },
   "about": {
     "pageTitle": "About",

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -2,7 +2,8 @@
   "nav": {
     "home": "Início",
     "about": "Sobre",
-    "blog": "Blog"
+    "blog": "Blog",
+    "projects": "Projetos"
   },
   "hero": {
     "title1": "Construindo, Aprendendo,",
@@ -74,6 +75,42 @@
     "linkedin": "Compartilhar no LinkedIn",
     "copyLink": "Copiar link",
     "copied": "Copiado!"
+  },
+  "projects": {
+    "pageTitle": "Projetos",
+    "pageDescription": "Projetos que estou construindo em público em EVM e Solana — apps onchain, ferramentas DeFi e infraestrutura para desenvolvedores.",
+    "hero": {
+      "label": "PROJETOS",
+      "title": "Projetos",
+      "tagline": "Construindo em público em EVM e Solana",
+      "description": "Uma lista corrente das coisas que estou lançando — apps onchain, experimentos em DeFi e ferramentas pra desenvolvedores. Alguns estão no ar, outros em testnets, todos são open source."
+    },
+    "list": {
+      "label": "O QUE ESTOU CONSTRUINDO"
+    },
+    "links": {
+      "code": "Código",
+      "visit": "Acessar",
+      "readPost": "Ler o post"
+    },
+    "items": {
+      "safenudge": {
+        "description": "Protocolo de poupança em grupo na Solana. Amigos se comprometem a poupar juntos; o blockchain impõe depósitos, cronograma e penalidades. Inspirado nos MOAIs brasileiros.",
+        "status": "No ar na devnet"
+      },
+      "basevault": {
+        "description": "Vault de yield DeFi na Base. Depósitos rendem via Aave v3. Construído com Solidity/Foundry, 100% de cobertura de testes, frontend com wagmi v2/viem v2.",
+        "status": "Deployado na Base Sepolia"
+      },
+      "flagkit": {
+        "description": "Serviço de feature flags self-hostable. API em Go com cache Redis, dashboard em React/TypeScript, SDK TypeScript publicado no npm.",
+        "status": "npm"
+      },
+      "solescrow": {
+        "description": "Programa de escrow em Anchor na devnet da Solana. Projeto de aprendizado cobrindo PDAs, CPIs e transferências de SPL tokens.",
+        "status": "No ar na devnet"
+      }
+    }
   },
   "about": {
     "pageTitle": "Sobre",


### PR DESCRIPTION
## Summary
- New `/projects` page following the editorial style of `/about` (hero + section label + draw-line divider + list).
- Reusable `ProjectCard` showing name, status badge in `text-primary`, description, mono-text tag pills, and GitHub / live / blog-post links.
- Four projects hardcoded in `projects-grid.tsx`: SafeNudge, BaseVault, FlagKit, SolEscrow.
- Translation keys added to `locales/en.json` and `locales/pt-BR.json` (including `nav.projects`).
- "Projects" added to `navItems` in `components/layout/header.tsx`.

## Test plan
- [ ] Visit `/projects` (EN) and `/pt-br/projects` — verify hero, section label, divider, four cards in correct order.
- [ ] Verify nav shows "Projects" / "Projetos" and active state highlights when on the page.
- [ ] Click each card's GitHub, live, and blog-post links.
- [ ] Confirm mobile layout (status badge stacks under title).

---
_Generated by [Claude Code](https://claude.ai/code/session_014SkcKx4DPPYbnSHusLpYXS)_