### PR TITLE
Add LinkedIn profile link to site social links

### DIFF
--- a/components/about/about-hero.tsx
+++ b/components/about/about-hero.tsx
@@ -11,6 +11,7 @@ export function AboutHero() {
     { name: 'Twitter', url: siteConfig.links.twitter },
     { name: 'Instagram', url: siteConfig.links.instagram },
     { name: 'YouTube', url: siteConfig.links.youtube },
+    { name: 'LinkedIn', url: siteConfig.links.linkedin },
   ];
 
   return (

--- a/components/layout/footer.tsx
+++ b/components/layout/footer.tsx
@@ -10,6 +10,7 @@ const socialLinks = [
   { href: siteConfig.links.instagram, label: "Instagram" },
   { href: siteConfig.links.youtube, label: "YouTube" },
   { href: siteConfig.links.github, label: "GitHub" },
+  { href: siteConfig.links.linkedin, label: "LinkedIn" },
 ]
 
 export function Footer() {

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -15,6 +15,7 @@ export const siteConfig = {
     instagram: "https://instagram.com/devgiroux",
     youtube: "https://youtube.com/@devgiroux",
     github: "https://github.com/davigiroux",
+    linkedin: "https://www.linkedin.com/in/davi-giroux",
   },
   // Giscus configuration - update after setting up your GitHub repo
   giscus: {


### PR DESCRIPTION
## Summary
- Searched the codebase for LinkedIn references; found only generic mentions (share button labels, docs) with no actual profile URL configured anywhere.
- Added `siteConfig.links.linkedin` (`https://www.linkedin.com/in/davi-giroux`) in `lib/config.ts`.
- Surfaced the new link in the footer social links list (`components/layout/footer.tsx`) and the about page social links list (`components/about/about-hero.tsx`), matching the existing pattern for Twitter/Instagram/YouTube/GitHub.

## Test plan
- [x] `npx tsc --noEmit` passes with no errors
- [ ] Visually confirm the LinkedIn link renders correctly in the footer and about page


---
_Generated by [Claude Code](https://claude.ai/code/session_01G4z9PYv4B1PTZPeK4TZZ3C)_